### PR TITLE
fix(pagination): remove totalPages and add hasMore flags to pagination

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -113,10 +113,10 @@ function utils.paginateTableWithCursor(tableArray, cursor, cursorField, limit, s
 		items = items,
 		limit = limit,
 		totalItems = #sortedTable,
-		totalPages = math.ceil(#sortedTable / limit),
 		sortBy = sortBy,
 		sortOrder = sortOrder,
 		nextCursor = nextCursor,
+		hasMore = nextCursor ~= nil,
 	}
 end
 


### PR DESCRIPTION
This is a clear indication of if there is more data to load. `totalPages` is removed as it suggests specific pages which is confusing when using cursor approach