### PR TITLE
feat(gar): add gateway weights to to regsitry

### DIFF
--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -488,6 +488,15 @@ describe("epochs", function()
 				local status = pcall(epochs.createEpoch, timestamp, epochStartBlockHeight, hashchain)
 				assert.is_true(status)
 				assert.are.same(expectation, epochs.getEpoch(epochIndex))
+				-- confirm the gateway weights were updated
+				assert.are.same({
+					stakeWeight = 1,
+					tenureWeight = 4,
+					gatewayRewardRatioWeight = 1,
+					observerRewardRatioWeight = 1,
+					compositeWeight = 4,
+					normalizedCompositeWeight = 1,
+				}, gar.getGateway("test-this-is-valid-arweave-wallet-address-1").weights)
 			end
 		)
 	end)

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -416,6 +416,41 @@ describe("epochs", function()
 		it(
 			"should create a new epoch for the given timestamp once distributions for the last epoch have occurred",
 			function()
+				_G.Epochs[0].distributions = {
+					totalEligibleRewards = 0,
+					totalDistributedRewards = 0,
+					distributedTimestamp = 0,
+					rewards = {},
+				}
+				_G.GatewayRegistry = {
+					["test-this-is-valid-arweave-wallet-address-1"] = {
+						operatorStake = gar.getSettings().operators.minStake,
+						totalDelegatedStake = 0,
+						vaults = {},
+						delegates = {},
+						startTimestamp = 0,
+						stats = {
+							prescribedEpochCount = 0,
+							observedEpochCount = 0,
+							totalEpochCount = 0,
+							passedEpochCount = 0,
+							failedEpochCount = 0,
+							failedConsecutiveEpochs = 0,
+							passedConsecutiveEpochs = 0,
+						},
+						settings = testSettings,
+						status = "joined",
+						observerAddress = "test-this-is-valid-arweave-wallet-address-1",
+						weights = {
+							stakeWeight = 0,
+							tenureWeight = 0,
+							gatewayRewardRatioWeight = 0,
+							observerRewardRatioWeight = 0,
+							compositeWeight = 0,
+							normalizedCompositeWeight = 0,
+						},
+					},
+				}
 				local settings = epochs.getSettings()
 				local epochIndex = 1
 				local epochStartTimestamp = settings.epochZeroStartTimestamp + settings.durationMs
@@ -433,19 +468,26 @@ describe("epochs", function()
 						failureSummaries = {},
 						reports = {},
 					},
-					prescribedObservers = {},
+					prescribedObservers = {
+						{
+							compositeWeight = 4.0,
+							gatewayAddress = "test-this-is-valid-arweave-wallet-address-1",
+							gatewayRewardRatioWeight = 1.0,
+							normalizedCompositeWeight = 1.0,
+							observerAddress = "test-this-is-valid-arweave-wallet-address-1",
+							observerRewardRatioWeight = 1.0,
+							stake = gar.getSettings().operators.minStake,
+							stakeWeight = 1.0,
+							startTimestamp = 0,
+							tenureWeight = 4,
+						},
+					},
 					prescribedNames = {},
 					distributions = {},
 				}
-				_G.Epochs[0].distributions = {
-					totalEligibleRewards = 0,
-					totalDistributedRewards = 0,
-					distributedTimestamp = 0,
-					rewards = {},
-				}
 				local status = pcall(epochs.createEpoch, timestamp, epochStartBlockHeight, hashchain)
 				assert.is_true(status)
-				assert.are.same(epochs.getEpoch(epochIndex), expectation)
+				assert.are.same(expectation, epochs.getEpoch(epochIndex))
 			end
 		)
 	end)

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -215,7 +215,8 @@ function epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
 		return a.normalizedCompositeWeight > b.normalizedCompositeWeight -- sort by descending weight
 	end)
 
-	return prescribedObservers
+	-- return the prescribed observers and the weighted observers
+	return prescribedObservers, weightedObservers
 end
 
 function epochs.getEpochTimestampsForIndex(epochIndex)
@@ -260,8 +261,9 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 
 	local epochStartTimestamp, epochEndTimestamp, epochDistributionTimestamp =
 		epochs.getEpochTimestampsForIndex(epochIndex)
-	local prescribedObservers = epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
+	local prescribedObservers, weights = epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
 	local prescribedNames = epochs.computePrescribedNamesForEpoch(epochIndex, hashchain)
+	-- create the epoch
 	local epoch = {
 		epochIndex = epochIndex,
 		startTimestamp = epochStartTimestamp,
@@ -277,6 +279,12 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 		distributions = {},
 	}
 	Epochs[epochIndex] = epoch
+	-- update the gateway weights
+	if weights then
+		for _, weightedGateway in ipairs(weights) do
+			gar.updateGatewayWeights(weightedGateway)
+		end
+	end
 end
 
 function epochs.saveObservations(observerAddress, reportTxId, failedGatewayAddresses, timestamp)

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -143,18 +143,18 @@ function epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
 
 	local epochStartTimestamp, epochEndTimestamp = epochs.getEpochTimestampsForIndex(epochIndex)
 	local activeGatewayAddresses = gar.getActiveGatewaysBetweenTimestamps(epochStartTimestamp, epochEndTimestamp)
-	local weightedObservers = gar.getGatewayWeightsAtTimestamp(activeGatewayAddresses, epochStartTimestamp)
+	local weightedGateways = gar.getGatewayWeightsAtTimestamp(activeGatewayAddresses, epochStartTimestamp)
 
 	-- Filter out any observers that could have a normalized composite weight of 0
 	local filteredObservers = {}
 	-- use ipairs as weightedObservers in array
-	for _, observer in ipairs(weightedObservers) do
+	for _, observer in ipairs(weightedGateways) do
 		if observer.normalizedCompositeWeight > 0 then
 			table.insert(filteredObservers, observer)
 		end
 	end
 	if #filteredObservers <= epochs.getSettings().maxObservers then
-		return filteredObservers
+		return filteredObservers, weightedGateways
 	end
 
 	-- the hash we will use to create entropy for prescribed observers
@@ -216,7 +216,7 @@ function epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
 	end)
 
 	-- return the prescribed observers and the weighted observers
-	return prescribedObservers, weightedObservers
+	return prescribedObservers, weightedGateways
 end
 
 function epochs.getEpochTimestampsForIndex(epochIndex)
@@ -261,7 +261,7 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 
 	local epochStartTimestamp, epochEndTimestamp, epochDistributionTimestamp =
 		epochs.getEpochTimestampsForIndex(epochIndex)
-	local prescribedObservers, weights = epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
+	local prescribedObservers, weightedGateways = epochs.computePrescribedObserversForEpoch(epochIndex, hashchain)
 	local prescribedNames = epochs.computePrescribedNamesForEpoch(epochIndex, hashchain)
 	-- create the epoch
 	local epoch = {
@@ -280,8 +280,8 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 	}
 	Epochs[epochIndex] = epoch
 	-- update the gateway weights
-	if weights then
-		for _, weightedGateway in ipairs(weights) do
+	if weightedGateways then
+		for _, weightedGateway in ipairs(weightedGateways) do
 			gar.updateGatewayWeights(weightedGateway)
 		end
 	end

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -553,6 +553,31 @@ function gar.updateGatewayStats(address, stats)
 	GatewayRegistry[address] = gateway
 end
 
+function gar.updateGatewayWeights(weightedGateway)
+	local address = weightedGateway.gatewayAddress
+	local gateway = gar.getGateway(address)
+	if gateway == nil then
+		error("Gateway does not exist")
+	end
+
+	assert(weightedGateway.stakeWeight, "stakeWeight is required")
+	assert(weightedGateway.tenureWeight, "tenureWeight is required")
+	assert(weightedGateway.gatewayRewardRatioWeight, "gatewayRewardRatioWeight is required")
+	assert(weightedGateway.observerRewardRatioWeight, "observerRewardRatioWeight is required")
+	assert(weightedGateway.compositeWeight, "compositeWeight is required")
+	assert(weightedGateway.normalizedCompositeWeight, "normalizedCompositeWeight is required")
+
+	gateway.weights = {
+		stakeWeight = weightedGateway.stakeWeight,
+		tenureWeight = weightedGateway.tenureWeight,
+		gatewayRewardRatioWeight = weightedGateway.gatewayRewardRatioWeight,
+		observerRewardRatioWeight = weightedGateway.observerRewardRatioWeight,
+		compositeWeight = weightedGateway.compositeWeight,
+		normalizedCompositeWeight = weightedGateway.normalizedCompositeWeight,
+	}
+	GatewayRegistry[address] = gateway
+end
+
 function gar.addGateway(address, gateway)
 	GatewayRegistry[address] = gateway
 end


### PR DESCRIPTION
We do all the work to compute these, but do not store them anywhere. Rather than doing more work on reads (and thus pay more gas to a CU) to compute them on the fly, we can store the weights at the beginning of an epoch and surface them in the network portal. It is important to note that weights will only change at the start of the next epoch.