### PR TITLE
fix(gar): fix how prescribedEpochCount is calculated

### DIFF
--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -445,7 +445,8 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 				failedConsecutiveEpochs = failed and gateway.stats.failedConsecutiveEpochs + 1 or 0,
 				passedConsecutiveEpochs = failed and 0 or gateway.stats.passedConsecutiveEpochs + 1,
 				passedEpochCount = failed and gateway.stats.passedEpochCount or gateway.stats.passedEpochCount + 1,
-				prescribedEpochCount = observerIndex ~= nil and gateway.stats.prescribedEpochCount + 1 or 0,
+				prescribedEpochCount = observerIndex and gateway.stats.prescribedEpochCount + 1
+					or gateway.stats.prescribedEpochCount,
 				observedEpochCount = observationSubmitted and gateway.stats.observedEpochCount + 1
 					or gateway.stats.observedEpochCount,
 			}


### PR DESCRIPTION
It is resetting to 0 if they are not prescribed, instead we want a running tally