### PR TITLE
feat(gar): support canceling withdrawls

### DIFF
--- a/src/gar.lua
+++ b/src/gar.lua
@@ -2,7 +2,7 @@
 local balances = require("balances")
 local utils = require("utils")
 local gar = {}
-
+local json = require("json")
 GatewayRegistry = GatewayRegistry or {}
 GatewayRegistrySettings = GatewayRegistrySettings
 	or {
@@ -673,6 +673,29 @@ function gar.getPaginatedGateways(cursor, limit, sortBy, sortOrder)
 	end
 
 	return utils.paginateTableWithCursor(gatewaysArray, cursor, cursorField, limit, sortBy, sortOrder)
+end
+
+function gar.cancelDelegateWithdrawal(from, gatewayAddress, vaultId)
+	local gateway = gar.getGateway(gatewayAddress)
+	if gateway == nil then
+		error("Gateway does not exist")
+	end
+
+	local delegate = gateway.delegates[from]
+	if delegate == nil then
+		error("Delegate does not exist")
+	end
+
+	local vault = delegate.vaults[vaultId]
+	if vault == nil then
+		error("Vault does not exist")
+	end
+
+	local vaultBalance = vault.balance
+	delegate.vaults[vaultId] = nil
+	delegate.delegatedStake = delegate.delegatedStake + vaultBalance
+	gateway.totalDelegatedStake = gateway.totalDelegatedStake + vaultBalance
+	GatewayRegistry[gatewayAddress] = gateway
 end
 
 return gar

--- a/src/main.lua
+++ b/src/main.lua
@@ -712,6 +712,42 @@ Handlers.add(ActionMap.DelegateStake, utils.hasMatchingTag("Action", ActionMap.D
 	end
 end)
 
+Handlers.add(ActionMap.CancelDelegateStake, utils.hasMatchingTag("Action", ActionMap.CancelDelegateStake), function(msg)
+	local checkAssertions = function()
+		assert(utils.isValidAOAddress(msg.Tags.Gateway), "Invalid gateway address")
+		assert(utils.isValidAOAddress(msg.Tags["Vault-Id"]), "Invalid vault id")
+	end
+
+	local inputStatus, inputResult = pcall(checkAssertions)
+
+	if not inputStatus then
+		ao.send({
+			Target = msg.From,
+			Tags = { Action = "Invalid-Cancel-Delegate-Stake-Notice", Error = "Bad-Input" },
+			Data = tostring(inputResult),
+		})
+		return
+	end
+
+	local gatewayAddress = utils.formatAddress(msg.Tags.Gateway)
+	local fromAddress = utils.formatAddress(msg.From)
+
+	local status, result = pcall(gar.cancelDelegateWithdrawal, fromAddress, gatewayAddress, msg.Tags["Vault-Id"])
+	if not status then
+		ao.send({
+			Target = msg.From,
+			Tags = { Action = "Invalid-Cancel-Delegate-Stake-Notice", Error = "Invalid-Cancel-Delegate-Stake" },
+			Data = tostring(result),
+		})
+	else
+		ao.send({
+			Target = msg.From,
+			Tags = { Action = "Cancel-Delegate-Stake-Notice", Gateway = msg.Tags.Target },
+			Data = json.encode(result),
+		})
+	end
+end)
+
 Handlers.add(
 	ActionMap.DecreaseDelegateStake,
 	utils.hasMatchingTag("Action", ActionMap.DecreaseDelegateStake),

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -262,7 +262,7 @@ describe('GatewayRegistry', async () => {
 
   describe('Decrease-Operator-Stake', () => {
     // join the network and then increase stake
-    it('should allow decrease the operator stake', async () => {
+    it('should allow decreasing the operator stake', async () => {
       // filter the operator-stake tag
       const overrideTags = validGatewayTags.filter(
         (tag) => tag.name !== 'Operator-Stake',
@@ -408,6 +408,144 @@ describe('GatewayRegistry', async () => {
           prescribedEpochCount: 0,
           observedEpochCount: 0,
         },
+      });
+    });
+  });
+
+  describe('Delegate-Stake', () => {
+    let sharedMemory;
+    // transfer some tokens to different address
+    const newStubAddress = 'stub-address-2'.padEnd(43, '0');
+
+    before(async () => {
+      const joinNetworkResult = await handle({
+        Tags: validGatewayTags,
+      });
+
+      const joinNetworkData = JSON.parse(joinNetworkResult.Messages[0].Data);
+
+      // transfer some tokens to different address
+      const transferResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Transfer' },
+            { name: 'Recipient', value: newStubAddress },
+            { name: 'Quantity', value: '1000000000' }, // 1K IO
+          ],
+        },
+        joinNetworkResult.Memory,
+      );
+      sharedMemory = transferResult.Memory;
+    });
+    it('should allow delegating stake', async () => {
+      const delegateStakeResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Delegate-Stake' },
+            { name: 'Quantity', value: '1000000000' }, // 1K IO
+          ],
+          From: newStubAddress,
+        },
+        sharedMemory.Memory,
+      );
+
+      // check the gateway record from contract
+      const gateway = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Gateway' },
+            { name: 'Address', value: STUB_ADDRESS },
+          ],
+        },
+        delegateStakeResult.Memory,
+      );
+      const gatewayData = JSON.parse(gateway.Messages[0].Data);
+      assert.deepEqual(
+        {
+          observerAddress: STUB_ADDRESS,
+          operatorStake: 0,
+          totalDelegatedStake: 1_000_000_000,
+          status: 'joined',
+          delegates: [
+            {
+              address: newStubAddress,
+              staked: 1_000_000_000,
+              reward: 0,
+            },
+          ],
+          vaults: [],
+          startTimestamp: joinNetworkData.startTimestamp,
+          settings: {
+            label: 'test-gateway',
+            note: 'test-note',
+            fqdn: 'test-fqdn',
+            port: 443,
+            protocol: 'https',
+            allowDelegatedStaking: true,
+          },
+        },
+        gatewayData,
+      );
+      sharedMemory = delegateStakeResult.Memory;
+    });
+
+    it('should allow with drawing stake from a gateway', async () => {
+      const withdrawDelegateStakeResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Withdraw-Delegate-Stake' },
+            { name: 'Gateway', value: STUB_ADDRESS },
+          ],
+          From: newStubAddress,
+        },
+        sharedMemory,
+      );
+      // get the gateway record
+      const gateway = await handle({
+        Tags: [
+          { name: 'Action', value: 'Gateway' },
+          { name: 'Address', value: STUB_ADDRESS },
+        ],
+      });
+      const gatewayData = JSON.parse(gateway.Messages[0].Data);
+      assert.deepEqual(gatewayData, {
+        observerAddress: STUB_ADDRESS,
+        operatorStake: 0,
+        totalDelegatedStake: 0,
+        status: 'joined',
+        delegates: [],
+        vaults: [],
+      });
+      sharedMemory = withdrawDelegateStakeResult.Memory;
+    });
+
+    it('should allow canceling a withdrawal', async () => {
+      const cancelWithdrawalResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Cancel-Delegate-Stake' },
+            { name: 'Gateway', value: STUB_ADDRESS },
+          ],
+        },
+        sharedMemory,
+      );
+
+      // now get the gateway record
+      const gateway = await handle({
+        Tags: [
+          { name: 'Action', value: 'Gateway' },
+          { name: 'Address', value: STUB_ADDRESS },
+        ],
+      });
+
+      const gatewayData = JSON.parse(gateway.Messages[0].Data);
+      assert.deepEqual(gatewayData, {
+        observerAddress: STUB_ADDRESS,
+        operatorStake: 0,
+        totalDelegatedStake: 0,
+        status: 'joined',
+        delegates: [],
+        vaults: [],
       });
     });
   });


### PR DESCRIPTION
Because tokens are locked for a signifigant amount of time, we will allow delegates to cancel their withdrawls so long as they have not expired.