### PR TITLE
feat(gar): support canceling delegate stake withdrawls 

### DIFF
--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -694,6 +694,43 @@ describe("gar", function()
 			)
 			assert.are.equal(1000, GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"].totalDelegatedStake)
 		end)
+		it("should not cancel a withdrawal if the gateway does not allow staking", function()
+			_G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"] = testGateway
+			_G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"].settings.allowDelegatedStaking = false
+			_G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"].delegates["test-this-is-valid-arweave-wallet-address-2"] =
+				{
+					delegatedStake = 0,
+					vaults = {
+						["some-previous-withdrawal-id"] = {
+							balance = 1000,
+							startTimestamp = 0,
+							endTimestamp = 1000,
+						},
+					},
+				}
+			local status, err = pcall(
+				gar.cancelDelegateWithdrawal,
+				"test-this-is-valid-arweave-wallet-address-2",
+				"test-this-is-valid-arweave-wallet-address-1",
+				"some-previous-withdrawal-id"
+			)
+			assert.is_false(status)
+			assert.is_not_nil(err)
+			assert.matches("Gateway does not allow staking", err)
+			assert.are.same(
+				{
+					delegatedStake = 0,
+					vaults = {
+						["some-previous-withdrawal-id"] = {
+							balance = 1000,
+							startTimestamp = 0,
+							endTimestamp = 1000,
+						},
+					},
+				},
+				_G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"].delegates["test-this-is-valid-arweave-wallet-address-2"]
+			)
+		end)
 	end)
 
 	describe("getters", function()

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -681,6 +681,10 @@ function gar.cancelDelegateWithdrawal(from, gatewayAddress, vaultId)
 		error("Gateway does not exist")
 	end
 
+	if gateway.status == "leaving" then
+		error("Gateway is leaving the network and cannot cancel withdrawals.")
+	end
+
 	local delegate = gateway.delegates[from]
 	if delegate == nil then
 		error("Delegate does not exist")

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -2,7 +2,7 @@
 local balances = require("balances")
 local utils = require("utils")
 local gar = {}
-local json = require("json")
+
 GatewayRegistry = GatewayRegistry or {}
 GatewayRegistrySettings = GatewayRegistrySettings
 	or {

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -691,6 +691,11 @@ function gar.cancelDelegateWithdrawal(from, gatewayAddress, vaultId)
 		error("Vault does not exist")
 	end
 
+	-- confirm the gateway still allow staking
+	if not gateway.settings.allowDelegatedStaking then
+		error("Gateway does not allow staking")
+	end
+
 	local vaultBalance = vault.balance
 	delegate.vaults[vaultId] = nil
 	delegate.delegatedStake = delegate.delegatedStake + vaultBalance

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -2,7 +2,7 @@
 local balances = require("balances")
 local utils = require("utils")
 local gar = {}
-
+local json = require("json")
 GatewayRegistry = GatewayRegistry or {}
 GatewayRegistrySettings = GatewayRegistrySettings
 	or {
@@ -673,6 +673,29 @@ function gar.getPaginatedGateways(cursor, limit, sortBy, sortOrder)
 	end
 
 	return utils.paginateTableWithCursor(gatewaysArray, cursor, cursorField, limit, sortBy, sortOrder)
+end
+
+function gar.cancelDelegateWithdrawal(from, gatewayAddress, vaultId)
+	local gateway = gar.getGateway(gatewayAddress)
+	if gateway == nil then
+		error("Gateway does not exist")
+	end
+
+	local delegate = gateway.delegates[from]
+	if delegate == nil then
+		error("Delegate does not exist")
+	end
+
+	local vault = delegate.vaults[vaultId]
+	if vault == nil then
+		error("Vault does not exist")
+	end
+
+	local vaultBalance = vault.balance
+	delegate.vaults[vaultId] = nil
+	delegate.delegatedStake = delegate.delegatedStake + vaultBalance
+	gateway.totalDelegatedStake = gateway.totalDelegatedStake + vaultBalance
+	GatewayRegistry[gatewayAddress] = gateway
 end
 
 return gar

--- a/src/main.lua
+++ b/src/main.lua
@@ -737,7 +737,7 @@ Handlers.add(
 		if not inputStatus then
 			ao.send({
 				Target = msg.From,
-				Tags = { Action = "Invalid-Cancel-Delegate-Stake-Notice", Error = "Bad-Input" },
+				Tags = { Action = "Invalid-Cancel-Delegate-Withdrawl-Notice", Error = "Bad-Input" },
 				Data = tostring(inputResult),
 			})
 			return

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -262,7 +262,7 @@ describe('GatewayRegistry', async () => {
 
   describe('Decrease-Operator-Stake', () => {
     // join the network and then increase stake
-    it('should allow decrease the operator stake', async () => {
+    it('should allow decreasing the operator stake', async () => {
       // filter the operator-stake tag
       const overrideTags = validGatewayTags.filter(
         (tag) => tag.name !== 'Operator-Stake',
@@ -412,141 +412,141 @@ describe('GatewayRegistry', async () => {
     });
   });
 
-  // describe.skip('Delegate-Stake', () => {
-  //   let sharedMemory;
-  //   // transfer some tokens to different address
-  //   const newStubAddress = 'stub-address-2'.padEnd(43, '0');
+  describe('Delegate-Stake', () => {
+    let sharedMemory;
+    // transfer some tokens to different address
+    const newStubAddress = 'stub-address-2'.padEnd(43, '0');
 
-  //   before(async () => {
-  //     const joinNetworkResult = await handle({
-  //       Tags: validGatewayTags,
-  //     });
+    before(async () => {
+      const joinNetworkResult = await handle({
+        Tags: validGatewayTags,
+      });
 
-  //     const joinNetworkData = JSON.parse(joinNetworkResult.Messages[0].Data);
+      const joinNetworkData = JSON.parse(joinNetworkResult.Messages[0].Data);
 
-  //     // transfer some tokens to different address
-  //     const transferResult = await handle(
-  //       {
-  //         Tags: [
-  //           { name: 'Action', value: 'Transfer' },
-  //           { name: 'Recipient', value: newStubAddress },
-  //           { name: 'Quantity', value: '1000000000' }, // 1K IO
-  //         ],
-  //       },
-  //       joinNetworkResult.Memory,
-  //     );
-  //     sharedMemory = transferResult.Memory;
-  //   });
-  //   it('should allow delegating stake', async () => {
-  //     const delegateStakeResult = await handle(
-  //       {
-  //         Tags: [
-  //           { name: 'Action', value: 'Delegate-Stake' },
-  //           { name: 'Quantity', value: '1000000000' }, // 1K IO
-  //         ],
-  //         From: newStubAddress,
-  //       },
-  //       sharedMemory.Memory,
-  //     );
+      // transfer some tokens to different address
+      const transferResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Transfer' },
+            { name: 'Recipient', value: newStubAddress },
+            { name: 'Quantity', value: '1000000000' }, // 1K IO
+          ],
+        },
+        joinNetworkResult.Memory,
+      );
+      sharedMemory = transferResult.Memory;
+    });
+    it('should allow delegating stake', async () => {
+      const delegateStakeResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Delegate-Stake' },
+            { name: 'Quantity', value: '1000000000' }, // 1K IO
+          ],
+          From: newStubAddress,
+        },
+        sharedMemory.Memory,
+      );
 
-  //     // check the gateway record from contract
-  //     const gateway = await handle(
-  //       {
-  //         Tags: [
-  //           { name: 'Action', value: 'Gateway' },
-  //           { name: 'Address', value: STUB_ADDRESS },
-  //         ],
-  //       },
-  //       delegateStakeResult.Memory,
-  //     );
-  //     const gatewayData = JSON.parse(gateway.Messages[0].Data);
-  //     assert.deepEqual(
-  //       {
-  //         observerAddress: STUB_ADDRESS,
-  //         operatorStake: 0,
-  //         totalDelegatedStake: 1_000_000_000,
-  //         status: 'joined',
-  //         delegates: [
-  //           {
-  //             address: newStubAddress,
-  //             staked: 1_000_000_000,
-  //             reward: 0,
-  //           },
-  //         ],
-  //         vaults: [],
-  //         startTimestamp: joinNetworkData.startTimestamp,
-  //         settings: {
-  //           label: 'test-gateway',
-  //           note: 'test-note',
-  //           fqdn: 'test-fqdn',
-  //           port: 443,
-  //           protocol: 'https',
-  //           allowDelegatedStaking: true,
-  //         },
-  //       },
-  //       gatewayData,
-  //     );
-  //     sharedMemory = delegateStakeResult.Memory;
-  //   });
+      // check the gateway record from contract
+      const gateway = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Gateway' },
+            { name: 'Address', value: STUB_ADDRESS },
+          ],
+        },
+        delegateStakeResult.Memory,
+      );
+      const gatewayData = JSON.parse(gateway.Messages[0].Data);
+      assert.deepEqual(
+        {
+          observerAddress: STUB_ADDRESS,
+          operatorStake: 0,
+          totalDelegatedStake: 1_000_000_000,
+          status: 'joined',
+          delegates: [
+            {
+              address: newStubAddress,
+              staked: 1_000_000_000,
+              reward: 0,
+            },
+          ],
+          vaults: [],
+          startTimestamp: joinNetworkData.startTimestamp,
+          settings: {
+            label: 'test-gateway',
+            note: 'test-note',
+            fqdn: 'test-fqdn',
+            port: 443,
+            protocol: 'https',
+            allowDelegatedStaking: true,
+          },
+        },
+        gatewayData,
+      );
+      sharedMemory = delegateStakeResult.Memory;
+    });
 
-  //   it('should allow with drawing stake from a gateway', async () => {
-  //     const withdrawDelegateStakeResult = await handle(
-  //       {
-  //         Tags: [
-  //           { name: 'Action', value: 'Withdraw-Delegate-Stake' },
-  //           { name: 'Gateway', value: STUB_ADDRESS },
-  //         ],
-  //         From: newStubAddress,
-  //       },
-  //       sharedMemory,
-  //     );
-  //     // get the gateway record
-  //     const gateway = await handle({
-  //       Tags: [
-  //         { name: 'Action', value: 'Gateway' },
-  //         { name: 'Address', value: STUB_ADDRESS },
-  //       ],
-  //     });
-  //     const gatewayData = JSON.parse(gateway.Messages[0].Data);
-  //     assert.deepEqual(gatewayData, {
-  //       observerAddress: STUB_ADDRESS,
-  //       operatorStake: 0,
-  //       totalDelegatedStake: 0,
-  //       status: 'joined',
-  //       delegates: [],
-  //       vaults: [],
-  //     });
-  //     sharedMemory = withdrawDelegateStakeResult.Memory;
-  //   });
+    it('should allow with drawing stake from a gateway', async () => {
+      const withdrawDelegateStakeResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Withdraw-Delegate-Stake' },
+            { name: 'Gateway', value: STUB_ADDRESS },
+          ],
+          From: newStubAddress,
+        },
+        sharedMemory,
+      );
+      // get the gateway record
+      const gateway = await handle({
+        Tags: [
+          { name: 'Action', value: 'Gateway' },
+          { name: 'Address', value: STUB_ADDRESS },
+        ],
+      });
+      const gatewayData = JSON.parse(gateway.Messages[0].Data);
+      assert.deepEqual(gatewayData, {
+        observerAddress: STUB_ADDRESS,
+        operatorStake: 0,
+        totalDelegatedStake: 0,
+        status: 'joined',
+        delegates: [],
+        vaults: [],
+      });
+      sharedMemory = withdrawDelegateStakeResult.Memory;
+    });
 
-  //   it('should allow canceling a withdrawal', async () => {
-  //     const cancelWithdrawalResult = await handle(
-  //       {
-  //         Tags: [
-  //           { name: 'Action', value: 'Cancel-Delegate-Stake' },
-  //           { name: 'Gateway', value: STUB_ADDRESS },
-  //         ],
-  //       },
-  //       sharedMemory,
-  //     );
+    it('should allow canceling a withdrawal', async () => {
+      const cancelWithdrawalResult = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Cancel-Delegate-Stake' },
+            { name: 'Gateway', value: STUB_ADDRESS },
+          ],
+        },
+        sharedMemory,
+      );
 
-  //     // now get the gateway record
-  //     const gateway = await handle({
-  //       Tags: [
-  //         { name: 'Action', value: 'Gateway' },
-  //         { name: 'Address', value: STUB_ADDRESS },
-  //       ],
-  //     });
+      // now get the gateway record
+      const gateway = await handle({
+        Tags: [
+          { name: 'Action', value: 'Gateway' },
+          { name: 'Address', value: STUB_ADDRESS },
+        ],
+      });
 
-  //     const gatewayData = JSON.parse(gateway.Messages[0].Data);
-  //     assert.deepEqual(gatewayData, {
-  //       observerAddress: STUB_ADDRESS,
-  //       operatorStake: 0,
-  //       totalDelegatedStake: 0,
-  //       status: 'joined',
-  //       delegates: [],
-  //       vaults: [],
-  //     });
-  //   });
-  // });
+      const gatewayData = JSON.parse(gateway.Messages[0].Data);
+      assert.deepEqual(gatewayData, {
+        observerAddress: STUB_ADDRESS,
+        operatorStake: 0,
+        totalDelegatedStake: 0,
+        status: 'joined',
+        delegates: [],
+        vaults: [],
+      });
+    });
+  });
 });

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -1,5 +1,5 @@
 import { createAosLoader } from './utils.mjs';
-import { describe, it } from 'node:test';
+import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 import {
   AO_LOADER_HANDLER_ENV,
@@ -8,6 +8,7 @@ import {
   validGatewayTags,
 } from '../tools/constants.mjs';
 
+const stubbedTimestamp = 1714857600000;
 describe('GatewayRegistry', async () => {
   const { handle: originalHandle, memory: startMemory } =
     await createAosLoader();
@@ -414,15 +415,16 @@ describe('GatewayRegistry', async () => {
 
   describe('Delegate-Stake', () => {
     let sharedMemory;
+    let joinedGateway;
     // transfer some tokens to different address
-    const newStubAddress = 'stub-address-2'.padEnd(43, '0');
+    const newStubAddress = ''.padEnd(43, '2');
 
     before(async () => {
       const joinNetworkResult = await handle({
         Tags: validGatewayTags,
       });
 
-      const joinNetworkData = JSON.parse(joinNetworkResult.Messages[0].Data);
+      joinedGateway = JSON.parse(joinNetworkResult.Messages[0].Data);
 
       // transfer some tokens to different address
       const transferResult = await handle(
@@ -437,16 +439,20 @@ describe('GatewayRegistry', async () => {
       );
       sharedMemory = transferResult.Memory;
     });
+
     it('should allow delegating stake', async () => {
       const delegateStakeResult = await handle(
         {
+          From: newStubAddress,
+          Owner: newStubAddress,
+          Timestamp: stubbedTimestamp,
           Tags: [
             { name: 'Action', value: 'Delegate-Stake' },
             { name: 'Quantity', value: '1000000000' }, // 1K IO
+            { name: 'Address', value: STUB_ADDRESS },
           ],
-          From: newStubAddress,
         },
-        sharedMemory.Memory,
+        sharedMemory,
       );
 
       // check the gateway record from contract
@@ -462,91 +468,101 @@ describe('GatewayRegistry', async () => {
       const gatewayData = JSON.parse(gateway.Messages[0].Data);
       assert.deepEqual(
         {
-          observerAddress: STUB_ADDRESS,
-          operatorStake: 0,
-          totalDelegatedStake: 1_000_000_000,
-          status: 'joined',
-          delegates: [
-            {
-              address: newStubAddress,
-              staked: 1_000_000_000,
-              reward: 0,
-            },
-          ],
-          vaults: [],
-          startTimestamp: joinNetworkData.startTimestamp,
-          settings: {
-            label: 'test-gateway',
-            note: 'test-note',
-            fqdn: 'test-fqdn',
-            port: 443,
-            protocol: 'https',
-            allowDelegatedStaking: true,
+          [newStubAddress]: {
+            delegatedStake: 1_000_000_000,
+            startTimestamp: stubbedTimestamp,
+            vaults: [],
           },
         },
-        gatewayData,
+        gatewayData.delegates,
       );
+      assert.deepEqual(gatewayData.totalDelegatedStake, 1_000_000_000);
       sharedMemory = delegateStakeResult.Memory;
     });
 
     it('should allow with drawing stake from a gateway', async () => {
-      const withdrawDelegateStakeResult = await handle(
+      const decreaseStakeTimestamp = stubbedTimestamp + 1000 * 60 * 15; // 15 minutes after stubbedTimestamp
+      const decreaseStakeResult = await handle(
         {
-          Tags: [
-            { name: 'Action', value: 'Withdraw-Delegate-Stake' },
-            { name: 'Gateway', value: STUB_ADDRESS },
-          ],
           From: newStubAddress,
+          Owner: newStubAddress,
+          Timestamp: decreaseStakeTimestamp,
+          Id: ''.padEnd(43, 'x'),
+          Tags: [
+            { name: 'Action', value: 'Decrease-Delegate-Stake' },
+            { name: 'Address', value: STUB_ADDRESS },
+            { name: 'Quantity', value: '1000000000' }, // 1K IO
+          ],
         },
         sharedMemory,
       );
       // get the gateway record
-      const gateway = await handle({
-        Tags: [
-          { name: 'Action', value: 'Gateway' },
-          { name: 'Address', value: STUB_ADDRESS },
-        ],
-      });
+      const gateway = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Gateway' },
+            { name: 'Address', value: STUB_ADDRESS },
+          ],
+          Timestamp: decreaseStakeTimestamp + 1,
+        },
+        decreaseStakeResult.Memory,
+      );
       const gatewayData = JSON.parse(gateway.Messages[0].Data);
-      assert.deepEqual(gatewayData, {
-        observerAddress: STUB_ADDRESS,
-        operatorStake: 0,
-        totalDelegatedStake: 0,
-        status: 'joined',
-        delegates: [],
-        vaults: [],
+      assert.deepEqual(gatewayData.delegates, {
+        [newStubAddress]: {
+          delegatedStake: 0,
+          startTimestamp: stubbedTimestamp,
+          vaults: {
+            [''.padEnd(43, 'x')]: {
+              balance: 1_000_000_000,
+              startTimestamp: decreaseStakeTimestamp, // 15 minutes after stubbedTimestamp
+              endTimestamp: decreaseStakeTimestamp + 1000 * 60 * 60 * 24 * 30, // 30 days
+            },
+          },
+        },
       });
-      sharedMemory = withdrawDelegateStakeResult.Memory;
+      assert.deepEqual(gatewayData.totalDelegatedStake, 0);
+      sharedMemory = decreaseStakeResult.Memory;
     });
 
     it('should allow canceling a withdrawal', async () => {
+      const cancelWithdrawalTimestamp = stubbedTimestamp + 1000 * 60 * 30; // 30 minutes after stubbedTimestamp
       const cancelWithdrawalResult = await handle(
         {
+          From: newStubAddress,
+          Owner: newStubAddress,
           Tags: [
-            { name: 'Action', value: 'Cancel-Delegate-Stake' },
-            { name: 'Gateway', value: STUB_ADDRESS },
+            { name: 'Action', value: 'Cancel-Delegate-Withdrawl' },
+            { name: 'Address', value: STUB_ADDRESS },
+            { name: 'Vault-Id', value: ''.padEnd(43, 'x') },
           ],
+          Timestamp: cancelWithdrawalTimestamp,
         },
         sharedMemory,
       );
 
       // now get the gateway record
-      const gateway = await handle({
-        Tags: [
-          { name: 'Action', value: 'Gateway' },
-          { name: 'Address', value: STUB_ADDRESS },
-        ],
-      });
+      const gateway = await handle(
+        {
+          Tags: [
+            { name: 'Action', value: 'Gateway' },
+            { name: 'Address', value: STUB_ADDRESS },
+          ],
+          Timestamp: cancelWithdrawalTimestamp + 1,
+        },
+        cancelWithdrawalResult.Memory,
+      );
 
       const gatewayData = JSON.parse(gateway.Messages[0].Data);
-      assert.deepEqual(gatewayData, {
-        observerAddress: STUB_ADDRESS,
-        operatorStake: 0,
-        totalDelegatedStake: 0,
-        status: 'joined',
-        delegates: [],
-        vaults: [],
+      assert.deepEqual(gatewayData.delegates, {
+        [newStubAddress]: {
+          delegatedStake: 1_000_000_000,
+          startTimestamp: stubbedTimestamp,
+          vaults: [],
+        },
       });
+      assert.deepEqual(gatewayData.totalDelegatedStake, 1_000_000_000);
+      sharedMemory = cancelWithdrawalResult.Memory;
     });
   });
 });


### PR DESCRIPTION
Because tokens are locked for a significant amount of time, we will allow delegates to cancel their withdrawls so long as they have not expired.
