### PR TITLE
chore(handlers): now that prune is after _default we do not want to k…

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -118,7 +118,7 @@ local function addRecordResultFields(ioEvent, result)
 end
 
 -- prune state before every interaction
-Handlers.after("_default").add("prune", function()
+Handlers.add("prune", function()
 	return "continue" -- continue is a pattern that matches every message and continues to the next handler that matches the tags
 end, function(msg)
 	assert(msg.Timestamp, "Timestamp is required for a tick interaction")


### PR DESCRIPTION
…eep adding it

Of course, `.after().add()` doesn't use the same logic as `Handlers.add()` so it does not replace the current handler if exists, and appends a new one, resulting in duplicates.

Now that `prune` is in the correct index, we can revert to `.add()` and we will make a future change to specifically set the index for each handler to deterministically set the order of our handlers.