### PR TITLE
PE-6791: Send arrays as as arrays rather than delimited lists

### DIFF
--- a/src/ao_event.lua
+++ b/src/ao_event.lua
@@ -14,13 +14,25 @@ local function AOEvent(initialData)
 		event.data = initialData
 	end
 
+	local function isValidTableValueType(table)
+		local valueType = type(value)
+		return valueType == "string" or valueType == "number" or valueType == "boolean" or value == nil
+	end
+
 	local function isValidType(value)
 		local valueType = type(value)
-		return valueType == "string"
-			or valueType == "number"
-			or valueType == "boolean"
-			or valueType == "table"
-			or value == nil
+		if valueType == "string" or valueType == "number" or valueType == "boolean" or value == nil then
+			return true
+		elseif valueType == "table" then
+			-- Prevent nested tables
+			for _, v in pairs(value) do
+				if not isValidTableValueType(v) then
+					return false
+				end
+			end
+			return true
+		end
+		return false
 	end
 
 	function event:addField(key, value)

--- a/src/ao_event.lua
+++ b/src/ao_event.lua
@@ -1,4 +1,6 @@
 local utils = require("utils")
+local json = require("json")
+
 -- Factory function for creating an "AOEvent"
 local function AOEvent(initialData)
 	local event = {
@@ -14,7 +16,11 @@ local function AOEvent(initialData)
 
 	local function isValidType(value)
 		local valueType = type(value)
-		return valueType == "string" or valueType == "number" or valueType == "boolean" or value == nil
+		return valueType == "string"
+			or valueType == "number"
+			or valueType == "boolean"
+			or valueType == "table"
+			or value == nil
 	end
 
 	function event:addField(key, value)
@@ -85,41 +91,9 @@ local function AOEvent(initialData)
 	end
 
 	function event:printEvent()
-		local serializedData = "{"
-
-		-- The _e: 1 flag signifies that this is an event
-		serializedData = serializedData .. '"_e": 1, '
-
-		-- Serialize event data
-		for key, value in pairs(self.data) do
-			local function processValue()
-				local serializedValue
-
-				if type(value) == "string" then
-					serializedValue = '"' .. escapeString(value) .. '"'
-				elseif type(value) == "number" or type(value) == "boolean" then
-					serializedValue = tostring(value)
-				elseif value == nil then
-					serializedValue = "null"
-				else
-					print("ERROR: Unsupported data type: " .. type(value))
-					return
-				end
-
-				serializedData = serializedData .. '"' .. key .. '": ' .. serializedValue .. ", "
-			end
-
-			processValue()
-		end
-
-		-- Remove trailing comma and space, if any
-		if string.sub(serializedData, -2) == ", " then
-			serializedData = string.sub(serializedData, 1, -3)
-		end
-
-		serializedData = serializedData .. "}"
-
-		print(serializedData)
+		-- The _e: 1 flag signifies that this is an event. Ensure it is set.
+		self.data["_e"] = 1
+		print(json.encode(self.data))
 	end
 
 	return event

--- a/src/ao_event.lua
+++ b/src/ao_event.lua
@@ -21,7 +21,7 @@ local function AOEvent(initialData)
 
 	local function isValidType(value)
 		local valueType = type(value)
-		if valueType == "string" or valueType == "number" or valueType == "boolean" or value == nil then
+		if isValidTableValueType(value) then
 			return true
 		elseif valueType == "table" then
 			-- Prevent nested tables

--- a/src/main.lua
+++ b/src/main.lua
@@ -88,7 +88,6 @@ local function eventingPcall(ioEvent, onError, fnToCall, ...)
 	if not status then
 		onError(result)
 		ioEvent:addField("Error", result)
-		ioEvent:printEvent()
 		return status
 	end
 	return status, result
@@ -129,6 +128,15 @@ local function gatewayStats()
 	}
 end
 
+local function addEventingHandler(handlerName, pattern, handleFn)
+	Handlers.add(handlerName, pattern, function(msg)
+		eventingPcall(msg.ioEvent, function()
+			-- No op
+		end, handleFn, msg)
+		msg.ioEvent:printEvent()
+	end)
+end
+
 -- prune state before every interaction
 Handlers.add("prune", function()
 	return "continue" -- continue is a pattern that matches every message and continues to the next handler that matches the tags
@@ -166,7 +174,7 @@ end, function(msg)
 	end
 
 	if resultOrError ~= nil then
-		local prunedRecordsCount = #(resultOrError.prunedRecords or {})
+		local prunedRecordsCount = utils.lengthOfTable(resultOrError.prunedRecords or {})
 		if prunedRecordsCount > 0 then
 			local prunedRecordNames = {}
 			for name, _ in pairs(resultOrError.prunedRecords) do
@@ -176,13 +184,13 @@ end, function(msg)
 			msg.ioEvent:addField("Pruned-Records-Count", prunedRecordsCount)
 			msg.ioEvent:addField("Records-Count", utils.lengthOfTable(NameRegistry.records))
 		end
-		local prunedEpochsCount = #(resultOrError.prunedEpochs or {})
+		local prunedEpochsCount = utils.lengthOfTable(resultOrError.prunedEpochs or {})
 		if prunedEpochsCount > 0 then
 			msg.ioEvent:addField("Pruned-Epochs", resultOrError.prunedEpochs)
 			msg.ioEvent:addField("Pruned-Epochs-Count", prunedEpochsCount)
 		end
 
-		local prunedGatewaysCount = #(resultOrError.prunedGateways or {})
+		local prunedGatewaysCount = utils.lengthOfTable(resultOrError.prunedGateways or {})
 		if prunedGatewaysCount > 0 then
 			msg.ioEvent:addField("Pruned-Gateways", resultOrError.prunedGateways)
 			msg.ioEvent:addField("Pruned-Gateways-Count", prunedGatewaysCount)
@@ -191,7 +199,7 @@ end, function(msg)
 			msg.ioEvent:addField("Leaving-Gateways-Count", gwStats.leaving)
 		end
 
-		local slashedGatewaysCount = #(resultOrError.slashedGateways or {})
+		local slashedGatewaysCount = utils.lengthOfTable(resultOrError.slashedGateways or {})
 		if slashedGatewaysCount > 0 then
 			msg.ioEvent:addField("Slashed-Gateways", resultOrError.slashedGateways)
 			msg.ioEvent:addField("Slashed-Gateways-Count", slashedGatewaysCount)
@@ -202,7 +210,7 @@ end, function(msg)
 end)
 
 -- Write handlers
-Handlers.add(ActionMap.Transfer, utils.hasMatchingTag("Action", ActionMap.Transfer), function(msg)
+addEventingHandler(ActionMap.Transfer, utils.hasMatchingTag("Action", ActionMap.Transfer), function(msg)
 	-- assert recipient is a valid arweave address
 	local function checkAssertions()
 		assert(utils.isValidAOAddress(msg.Tags.Recipient), "Invalid recipient")
@@ -286,10 +294,9 @@ Handlers.add(ActionMap.Transfer, utils.hasMatchingTag("Action", ActionMap.Transf
 		ao.send(debitNotice)
 		ao.send(creditNotice)
 	end
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.CreateVault, utils.hasMatchingTag("Action", ActionMap.CreateVault), function(msg)
+addEventingHandler(ActionMap.CreateVault, utils.hasMatchingTag("Action", ActionMap.CreateVault), function(msg)
 	local function checkAssertions()
 		assert(
 			msg.Tags["Lock-Length"]
@@ -349,10 +356,9 @@ Handlers.add(ActionMap.CreateVault, utils.hasMatchingTag("Action", ActionMap.Cre
 		},
 		Data = json.encode(vault),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.VaultedTransfer, utils.hasMatchingTag("Action", ActionMap.VaultedTransfer), function(msg)
+addEventingHandler(ActionMap.VaultedTransfer, utils.hasMatchingTag("Action", ActionMap.VaultedTransfer), function(msg)
 	local function checkAssertions()
 		assert(utils.isValidArweaveAddress(msg.Tags.Recipient), "Invalid recipient")
 		assert(
@@ -406,7 +412,7 @@ Handlers.add(ActionMap.VaultedTransfer, utils.hasMatchingTag("Action", ActionMap
 	end
 end)
 
-Handlers.add(ActionMap.ExtendVault, utils.hasMatchingTag("Action", ActionMap.ExtendVault), function(msg)
+addEventingHandler(ActionMap.ExtendVault, utils.hasMatchingTag("Action", ActionMap.ExtendVault), function(msg)
 	local checkAssertions = function()
 		assert(utils.isValidArweaveAddress(msg.Tags["Vault-Id"]), "Invalid vault id")
 		assert(
@@ -452,10 +458,9 @@ Handlers.add(ActionMap.ExtendVault, utils.hasMatchingTag("Action", ActionMap.Ext
 		Tags = { Action = "Vault-Extended-Notice" },
 		Data = json.encode(vault),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.IncreaseVault, utils.hasMatchingTag("Action", ActionMap.IncreaseVault), function(msg)
+addEventingHandler(ActionMap.IncreaseVault, utils.hasMatchingTag("Action", ActionMap.IncreaseVault), function(msg)
 	local function checkAssertions()
 		assert(utils.isValidArweaveAddress(msg.Tags["Vault-Id"]), "Invalid vault id")
 		assert(
@@ -502,10 +507,9 @@ Handlers.add(ActionMap.IncreaseVault, utils.hasMatchingTag("Action", ActionMap.I
 		Tags = { Action = "Vault-Increased-Notice" },
 		Data = json.encode(vault),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.BuyRecord, utils.hasMatchingTag("Action", ActionMap.BuyRecord), function(msg)
+addEventingHandler(ActionMap.BuyRecord, utils.hasMatchingTag("Action", ActionMap.BuyRecord), function(msg)
 	local checkAssertions = function()
 		assert(type(msg.Tags.Name) == "string", "Invalid name")
 		assert(type(msg.Tags["Purchase-Type"]) == "string", "Invalid purchase type")
@@ -570,10 +574,9 @@ Handlers.add(ActionMap.BuyRecord, utils.hasMatchingTag("Action", ActionMap.BuyRe
 		Tags = { Action = "Buy-Record-Notice", Name = msg.Tags.Name },
 		Data = json.encode(record),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.ExtendLease, utils.hasMatchingTag("Action", ActionMap.ExtendLease), function(msg)
+addEventingHandler(ActionMap.ExtendLease, utils.hasMatchingTag("Action", ActionMap.ExtendLease), function(msg)
 	local checkAssertions = function()
 		assert(type(msg.Tags.Name) == "string", "Invalid name")
 		assert(
@@ -616,10 +619,9 @@ Handlers.add(ActionMap.ExtendLease, utils.hasMatchingTag("Action", ActionMap.Ext
 		Tags = { Action = "Extend-Lease-Notice", Name = string.lower(msg.Tags.Name) },
 		Data = json.encode(recordResult),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.IncreaseUndernameLimit,
 	utils.hasMatchingTag("Action", ActionMap.IncreaseUndernameLimit),
 	function(msg)
@@ -676,11 +678,10 @@ Handlers.add(
 			Tags = { Action = "Increase-Undername-Limit-Notice", Name = string.lower(msg.Tags.Name) },
 			Data = json.encode(recordResult),
 		})
-		msg.ioEvent:printEvent()
 	end
 )
 
-Handlers.add(ActionMap.TokenCost, utils.hasMatchingTag("Action", ActionMap.TokenCost), function(msg)
+addEventingHandler(ActionMap.TokenCost, utils.hasMatchingTag("Action", ActionMap.TokenCost), function(msg)
 	local checkAssertions = function()
 		assert(
 			type(msg.Tags.Intent) == "string",
@@ -736,25 +737,29 @@ Handlers.add(ActionMap.TokenCost, utils.hasMatchingTag("Action", ActionMap.Token
 	end
 end)
 
-Handlers.add(ActionMap.GetRegistrationFees, utils.hasMatchingTag("Action", ActionMap.GetRegistrationFees), function(msg)
-	local status, priceList = pcall(arns.getRegistrationFees)
+addEventingHandler(
+	ActionMap.GetRegistrationFees,
+	utils.hasMatchingTag("Action", ActionMap.GetRegistrationFees),
+	function(msg)
+		local status, priceList = pcall(arns.getRegistrationFees)
 
-	if not status then
-		ao.send({
-			Target = msg.From,
-			Tags = { Action = "Invalid-Get-Registration-Fees-Notice", Error = "Invalid-Get-Registration-Fees" },
-			Data = tostring(priceList),
-		})
-	else
-		ao.send({
-			Target = msg.From,
-			Tags = { Action = "Get-Registration-Fees-Notice" },
-			Data = json.encode(priceList),
-		})
+		if not status then
+			ao.send({
+				Target = msg.From,
+				Tags = { Action = "Invalid-Get-Registration-Fees-Notice", Error = "Invalid-Get-Registration-Fees" },
+				Data = tostring(priceList),
+			})
+		else
+			ao.send({
+				Target = msg.From,
+				Tags = { Action = "Get-Registration-Fees-Notice" },
+				Data = json.encode(priceList),
+			})
+		end
 	end
-end)
+)
 
-Handlers.add(ActionMap.JoinNetwork, utils.hasMatchingTag("Action", ActionMap.JoinNetwork), function(msg)
+addEventingHandler(ActionMap.JoinNetwork, utils.hasMatchingTag("Action", ActionMap.JoinNetwork), function(msg)
 	local updatedSettings = {
 		label = msg.Tags.Label,
 		note = msg.Tags.Note,
@@ -804,10 +809,9 @@ Handlers.add(ActionMap.JoinNetwork, utils.hasMatchingTag("Action", ActionMap.Joi
 		Tags = { Action = "Join-Network-Notice" },
 		Data = json.encode(gateway),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.LeaveNetwork, utils.hasMatchingTag("Action", ActionMap.LeaveNetwork), function(msg)
+addEventingHandler(ActionMap.LeaveNetwork, utils.hasMatchingTag("Action", ActionMap.LeaveNetwork), function(msg)
 	local shouldContinue, gateway = eventingPcall(msg.ioEvent, function(error)
 		ao.send({
 			Target = msg.From,
@@ -857,10 +861,9 @@ Handlers.add(ActionMap.LeaveNetwork, utils.hasMatchingTag("Action", ActionMap.Le
 		Tags = { Action = "Leave-Network-Notice" },
 		Data = json.encode(gateway),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.IncreaseOperatorStake,
 	utils.hasMatchingTag("Action", ActionMap.IncreaseOperatorStake),
 	function(msg)
@@ -907,11 +910,10 @@ Handlers.add(
 			Tags = { Action = "Increase-Operator-Stake-Notice" },
 			Data = json.encode(gateway),
 		})
-		msg.ioEvent:printEvent()
 	end
 )
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.DecreaseOperatorStake,
 	utils.hasMatchingTag("Action", ActionMap.DecreaseOperatorStake),
 	function(msg)
@@ -969,11 +971,10 @@ Handlers.add(
 			Tags = { Action = "Decrease-Operator-Stake-Notice" },
 			Data = json.encode(gateway),
 		})
-		msg.ioEvent:printEvent()
 	end
 )
 
-Handlers.add(ActionMap.DelegateStake, utils.hasMatchingTag("Action", ActionMap.DelegateStake), function(msg)
+addEventingHandler(ActionMap.DelegateStake, utils.hasMatchingTag("Action", ActionMap.DelegateStake), function(msg)
 	local checkAssertions = function()
 		assert(utils.isValidAOAddress(msg.Tags.Target or msg.Tags.Address), "Invalid target address")
 		assert(
@@ -1023,10 +1024,9 @@ Handlers.add(ActionMap.DelegateStake, utils.hasMatchingTag("Action", ActionMap.D
 		Tags = { Action = "Delegate-Stake-Notice", Gateway = msg.Tags.Target },
 		Data = json.encode(delegateResult),
 	})
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.CancelDelegateWithdrawal,
 	utils.hasMatchingTag("Action", ActionMap.CancelDelegateWithdrawal),
 	function(msg)
@@ -1085,11 +1085,10 @@ Handlers.add(
 			},
 			Data = json.encode(delegateResult),
 		})
-		msg.ioEvent:printEvent()
 	end
 )
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.DecreaseDelegateStake,
 	utils.hasMatchingTag("Action", ActionMap.DecreaseDelegateStake),
 	function(msg)
@@ -1154,11 +1153,10 @@ Handlers.add(
 			Tags = { Action = "Decrease-Delegate-Stake-Notice", Adddress = target, Quantity = msg.Tags.Quantity },
 			Data = json.encode(delegateResult),
 		})
-		msg.ioEvent:printEvent()
 	end
 )
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.UpdateGatewaySettings,
 	utils.hasMatchingTag("Action", ActionMap.UpdateGatewaySettings),
 	function(msg)
@@ -1206,7 +1204,7 @@ Handlers.add(
 	end
 )
 
-Handlers.add(ActionMap.SaveObservations, utils.hasMatchingTag("Action", ActionMap.SaveObservations), function(msg)
+addEventingHandler(ActionMap.SaveObservations, utils.hasMatchingTag("Action", ActionMap.SaveObservations), function(msg)
 	local reportTxId = msg.Tags["Report-Tx-Id"]
 	local failedGateways = utils.splitString(msg.Tags["Failed-Gateways"], ",")
 	local checkAssertions = function()
@@ -1249,10 +1247,9 @@ Handlers.add(ActionMap.SaveObservations, utils.hasMatchingTag("Action", ActionMa
 	end
 
 	ao.send({ Target = msg.From, Action = "Save-Observations-Notice", Data = json.encode(observations) })
-	msg.ioEvent:printEvent()
 end)
 
-Handlers.add(ActionMap.EpochSettings, utils.hasMatchingTag("Action", ActionMap.EpochSettings), function(msg)
+addEventingHandler(ActionMap.EpochSettings, utils.hasMatchingTag("Action", ActionMap.EpochSettings), function(msg)
 	local epochSettings = epochs.getSettings()
 	ao.send({
 		Target = msg.From,
@@ -1261,7 +1258,7 @@ Handlers.add(ActionMap.EpochSettings, utils.hasMatchingTag("Action", ActionMap.E
 	})
 end)
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.DemandFactorSettings,
 	utils.hasMatchingTag("Action", ActionMap.DemandFactorSettings),
 	function(msg)
@@ -1274,7 +1271,7 @@ Handlers.add(
 	end
 )
 
-Handlers.add(
+addEventingHandler(
 	ActionMap.GatewayRegistrySettings,
 	utils.hasMatchingTag("Action", ActionMap.GatewayRegistrySettings),
 	function(msg)
@@ -1287,7 +1284,7 @@ Handlers.add(
 	end
 )
 
-Handlers.add("totalTokenSupply", utils.hasMatchingTag("Action", "Total-Token-Supply"), function(msg)
+addEventingHandler("totalTokenSupply", utils.hasMatchingTag("Action", "Total-Token-Supply"), function(msg)
 	-- add all the balances
 	local totalSupply = 0
 	local balances = balances.getBalances()
@@ -1328,7 +1325,7 @@ Handlers.add("totalTokenSupply", utils.hasMatchingTag("Action", "Total-Token-Sup
 end)
 
 -- TICK HANDLER - TODO: this may be better as a "Distribute" rewards handler instead of `Tick` tag
-Handlers.add("distribute", utils.hasMatchingTag("Action", "Tick"), function(msg)
+addEventingHandler("distribute", utils.hasMatchingTag("Action", "Tick"), function(msg)
 	assert(msg.Timestamp, "Timestamp is required for a tick interaction")
 	local msgTimestamp = tonumber(msg.Timestamp)
 	-- tick and distribute rewards for every index between the last ticked epoch and the current epoch
@@ -1432,7 +1429,7 @@ end)
 
 -- READ HANDLERS
 
-Handlers.add(ActionMap.Info, Handlers.utils.hasMatchingTag("Action", ActionMap.Info), function(msg)
+addEventingHandler(ActionMap.Info, Handlers.utils.hasMatchingTag("Action", ActionMap.Info), function(msg)
 	local handlers = Handlers.list
 	local handlerNames = {}
 	for _, handler in ipairs(handlers) do
@@ -1463,7 +1460,7 @@ Handlers.add(ActionMap.Info, Handlers.utils.hasMatchingTag("Action", ActionMap.I
 	})
 end)
 
-Handlers.add(ActionMap.State, Handlers.utils.hasMatchingTag("Action", ActionMap.State), function(msg)
+addEventingHandler(ActionMap.State, Handlers.utils.hasMatchingTag("Action", ActionMap.State), function(msg)
 	ao.send({
 		Target = msg.From,
 		Action = "State-Notice",
@@ -1481,7 +1478,7 @@ Handlers.add(ActionMap.State, Handlers.utils.hasMatchingTag("Action", ActionMap.
 	})
 end)
 
-Handlers.add(ActionMap.Gateways, Handlers.utils.hasMatchingTag("Action", ActionMap.Gateways), function(msg)
+addEventingHandler(ActionMap.Gateways, Handlers.utils.hasMatchingTag("Action", ActionMap.Gateways), function(msg)
 	local gateways = gar.getGateways()
 	ao.send({
 		Target = msg.From,
@@ -1490,7 +1487,7 @@ Handlers.add(ActionMap.Gateways, Handlers.utils.hasMatchingTag("Action", ActionM
 	})
 end)
 
-Handlers.add(ActionMap.Gateway, Handlers.utils.hasMatchingTag("Action", ActionMap.Gateway), function(msg)
+addEventingHandler(ActionMap.Gateway, Handlers.utils.hasMatchingTag("Action", ActionMap.Gateway), function(msg)
 	local gateway = gar.getGateway(msg.Tags.Address or msg.From)
 	ao.send({
 		Target = msg.From,
@@ -1500,7 +1497,7 @@ Handlers.add(ActionMap.Gateway, Handlers.utils.hasMatchingTag("Action", ActionMa
 	})
 end)
 
-Handlers.add(ActionMap.Balances, Handlers.utils.hasMatchingTag("Action", ActionMap.Balances), function(msg)
+addEventingHandler(ActionMap.Balances, Handlers.utils.hasMatchingTag("Action", ActionMap.Balances), function(msg)
 	ao.send({
 		Target = msg.From,
 		Action = "Balances-Notice",
@@ -1508,7 +1505,7 @@ Handlers.add(ActionMap.Balances, Handlers.utils.hasMatchingTag("Action", ActionM
 	})
 end)
 
-Handlers.add(ActionMap.Balance, Handlers.utils.hasMatchingTag("Action", ActionMap.Balance), function(msg)
+addEventingHandler(ActionMap.Balance, Handlers.utils.hasMatchingTag("Action", ActionMap.Balance), function(msg)
 	local target = utils.formatAddress(msg.Tags.Target or msg.Tags.Address or msg.From)
 
 	-- TODO: arconnect et. all expect to accept Target
@@ -1524,7 +1521,7 @@ Handlers.add(ActionMap.Balance, Handlers.utils.hasMatchingTag("Action", ActionMa
 	})
 end)
 
-Handlers.add(ActionMap.DemandFactor, utils.hasMatchingTag("Action", ActionMap.DemandFactor), function(msg)
+addEventingHandler(ActionMap.DemandFactor, utils.hasMatchingTag("Action", ActionMap.DemandFactor), function(msg)
 	-- wrap in a protected call, and return the result or error accoringly to sender
 	local status, result = pcall(demand.getDemandFactor)
 	if status then
@@ -1539,7 +1536,7 @@ Handlers.add(ActionMap.DemandFactor, utils.hasMatchingTag("Action", ActionMap.De
 	end
 end)
 
-Handlers.add(ActionMap.DemandFactorInfo, utils.hasMatchingTag("Action", ActionMap.DemandFactorInfo), function(msg)
+addEventingHandler(ActionMap.DemandFactorInfo, utils.hasMatchingTag("Action", ActionMap.DemandFactorInfo), function(msg)
 	local status, result = pcall(demand.getDemandFactorInfo)
 	if status then
 		ao.send({ Target = msg.From, Action = "Demand-Factor-Info-Notice", Data = json.encode(result) })
@@ -1553,7 +1550,7 @@ Handlers.add(ActionMap.DemandFactorInfo, utils.hasMatchingTag("Action", ActionMa
 	end
 end)
 
-Handlers.add(ActionMap.Record, utils.hasMatchingTag("Action", ActionMap.Record), function(msg)
+addEventingHandler(ActionMap.Record, utils.hasMatchingTag("Action", ActionMap.Record), function(msg)
 	local record = arns.getRecord(msg.Tags.Name)
 
 	local recordNotice = {
@@ -1575,7 +1572,7 @@ Handlers.add(ActionMap.Record, utils.hasMatchingTag("Action", ActionMap.Record),
 	ao.send(recordNotice)
 end)
 
-Handlers.add(ActionMap.Records, utils.hasMatchingTag("Action", ActionMap.Records), function(msg)
+addEventingHandler(ActionMap.Records, utils.hasMatchingTag("Action", ActionMap.Records), function(msg)
 	local records = arns.getRecords()
 
 	-- Credit-Notice message template, that is sent to the Recipient of the transfer
@@ -1597,7 +1594,7 @@ Handlers.add(ActionMap.Records, utils.hasMatchingTag("Action", ActionMap.Records
 	ao.send(recordsNotice)
 end)
 
-Handlers.add(ActionMap.Epoch, utils.hasMatchingTag("Action", ActionMap.Epoch), function(msg)
+addEventingHandler(ActionMap.Epoch, utils.hasMatchingTag("Action", ActionMap.Epoch), function(msg)
 	-- check if the epoch number is provided, if not get the epoch number from the timestamp
 	local checkAssertions = function()
 		assert(msg.Tags["Epoch-Index"] or msg.Tags.Timestamp or msg.Timestamp, "Epoch index or timestamp is required")
@@ -1620,34 +1617,42 @@ Handlers.add(ActionMap.Epoch, utils.hasMatchingTag("Action", ActionMap.Epoch), f
 	ao.send({ Target = msg.From, Action = "Epoch-Notice", Data = json.encode(epoch) })
 end)
 
-Handlers.add(ActionMap.Epochs, utils.hasMatchingTag("Action", ActionMap.Epochs), function(msg)
+addEventingHandler(ActionMap.Epochs, utils.hasMatchingTag("Action", ActionMap.Epochs), function(msg)
 	local epochs = epochs.getEpochs()
 	ao.send({ Target = msg.From, Action = "Epochs-Notice", Data = epochs })
 end)
 
-Handlers.add(ActionMap.PrescribedObservers, utils.hasMatchingTag("Action", ActionMap.PrescribedObservers), function(msg)
-	-- check if the epoch number is provided, if not get the epoch number from the timestamp
-	local checkAssertions = function()
-		assert(msg.Tags["Epoch-Index"] or msg.Timestamp or msg.Tags.Timestamp, "Epoch index or timestamp is required")
+addEventingHandler(
+	ActionMap.PrescribedObservers,
+	utils.hasMatchingTag("Action", ActionMap.PrescribedObservers),
+	function(msg)
+		-- check if the epoch number is provided, if not get the epoch number from the timestamp
+		local checkAssertions = function()
+			assert(
+				msg.Tags["Epoch-Index"] or msg.Timestamp or msg.Tags.Timestamp,
+				"Epoch index or timestamp is required"
+			)
+		end
+
+		local inputStatus, inputResult = pcall(checkAssertions)
+
+		if not inputStatus then
+			ao.send({
+				Target = msg.From,
+				Tags = { Action = "Invalid-Prescribed-Observers-Notice", Error = "Bad-Input" },
+				Data = tostring(inputResult),
+			})
+			return
+		end
+
+		local epochIndex = tonumber(msg.Tags["Epoch-Index"])
+			or epochs.getEpochIndexForTimestamp(tonumber(msg.Timestamp))
+		local prescribedObservers = epochs.getPrescribedObserversForEpoch(epochIndex)
+		ao.send({ Target = msg.From, Action = "Prescribed-Observers-Notice", Data = json.encode(prescribedObservers) })
 	end
+)
 
-	local inputStatus, inputResult = pcall(checkAssertions)
-
-	if not inputStatus then
-		ao.send({
-			Target = msg.From,
-			Tags = { Action = "Invalid-Prescribed-Observers-Notice", Error = "Bad-Input" },
-			Data = tostring(inputResult),
-		})
-		return
-	end
-
-	local epochIndex = tonumber(msg.Tags["Epoch-Index"]) or epochs.getEpochIndexForTimestamp(tonumber(msg.Timestamp))
-	local prescribedObservers = epochs.getPrescribedObserversForEpoch(epochIndex)
-	ao.send({ Target = msg.From, Action = "Prescribed-Observers-Notice", Data = json.encode(prescribedObservers) })
-end)
-
-Handlers.add(ActionMap.Observations, utils.hasMatchingTag("Action", ActionMap.Observations), function(msg)
+addEventingHandler(ActionMap.Observations, utils.hasMatchingTag("Action", ActionMap.Observations), function(msg)
 	-- check if the epoch number is provided, if not get the epoch number from the timestamp
 	local checkAssertions = function()
 		assert(msg.Tags["Epoch-Index"] or msg.Timestamp or msg.Tags.Timestamp, "Epoch index or timestamp is required")
@@ -1675,7 +1680,7 @@ Handlers.add(ActionMap.Observations, utils.hasMatchingTag("Action", ActionMap.Ob
 	})
 end)
 
-Handlers.add(ActionMap.PrescribedNames, utils.hasMatchingTag("Action", ActionMap.PrescribedNames), function(msg)
+addEventingHandler(ActionMap.PrescribedNames, utils.hasMatchingTag("Action", ActionMap.PrescribedNames), function(msg)
 	-- check if the epoch number is provided, if not get the epoch number from the timestamp
 	local checkAssertions = function()
 		assert(msg.Tags["Epoch-Index"] or msg.Tags.Timestamp or msg.Timestamp, "Epoch index or timestamp is required")
@@ -1698,7 +1703,7 @@ Handlers.add(ActionMap.PrescribedNames, utils.hasMatchingTag("Action", ActionMap
 	ao.send({ Target = msg.From, Action = "Prescribed-Names-Notice", Data = json.encode(prescribedNames) })
 end)
 
-Handlers.add(ActionMap.Distributions, utils.hasMatchingTag("Action", ActionMap.Distributions), function(msg)
+addEventingHandler(ActionMap.Distributions, utils.hasMatchingTag("Action", ActionMap.Distributions), function(msg)
 	-- check if the epoch number is provided, if not get the epoch number from the timestamp
 	local checkAssertions = function()
 		assert(msg.Tags["Epoch-Index"] or msg.Timestamp or msg.Tags.Timestamp, "Epoch index or timestamp is required")
@@ -1721,12 +1726,12 @@ Handlers.add(ActionMap.Distributions, utils.hasMatchingTag("Action", ActionMap.D
 	ao.send({ Target = msg.From, Action = "Distributions-Notice", Data = json.encode(distributions) })
 end)
 
-Handlers.add(ActionMap.ReservedNames, utils.hasMatchingTag("Action", ActionMap.ReservedNames), function(msg)
+addEventingHandler(ActionMap.ReservedNames, utils.hasMatchingTag("Action", ActionMap.ReservedNames), function(msg)
 	local reservedNames = arns.getReservedNames()
 	ao.send({ Target = msg.From, Action = "Reserved-Names-Notice", Data = json.encode(reservedNames) })
 end)
 
-Handlers.add(ActionMap.ReservedName, utils.hasMatchingTag("Action", ActionMap.ReservedName), function(msg)
+addEventingHandler(ActionMap.ReservedName, utils.hasMatchingTag("Action", ActionMap.ReservedName), function(msg)
 	local reservedName = arns.getReservedName(msg.Tags.Name)
 	ao.send({
 		Target = msg.From,
@@ -1736,11 +1741,11 @@ Handlers.add(ActionMap.ReservedName, utils.hasMatchingTag("Action", ActionMap.Re
 	})
 end)
 
-Handlers.add(ActionMap.Vaults, utils.hasMatchingTag("Action", ActionMap.Vaults), function(msg)
+addEventingHandler(ActionMap.Vaults, utils.hasMatchingTag("Action", ActionMap.Vaults), function(msg)
 	ao.send({ Target = msg.From, Action = "Vaults-Notice", Data = json.encode(Vaults) })
 end)
 
-Handlers.add(ActionMap.Vault, utils.hasMatchingTag("Action", ActionMap.Vault), function(msg)
+addEventingHandler(ActionMap.Vault, utils.hasMatchingTag("Action", ActionMap.Vault), function(msg)
 	local address = msg.Tags.Address or msg.From
 	local vaultId = msg.Tags["Vault-Id"]
 	local vault = vaults.getVault(address, vaultId)
@@ -1768,7 +1773,7 @@ end)
 
 -- Pagination handlers
 
-Handlers.add("paginatedRecords", utils.hasMatchingTag("Action", "Paginated-Records"), function(msg)
+addEventingHandler("paginatedRecords", utils.hasMatchingTag("Action", "Paginated-Records"), function(msg)
 	local page = utils.parsePaginationTags(msg)
 	local status, result =
 		pcall(arns.getPaginatedRecords, page.cursor, page.limit, page.sortBy or "startTimestamp", page.sortOrder)
@@ -1784,7 +1789,7 @@ Handlers.add("paginatedRecords", utils.hasMatchingTag("Action", "Paginated-Recor
 	end
 end)
 
-Handlers.add("paginatedGateways", utils.hasMatchingTag("Action", "Paginated-Gateways"), function(msg)
+addEventingHandler("paginatedGateways", utils.hasMatchingTag("Action", "Paginated-Gateways"), function(msg)
 	local page = utils.parsePaginationTags(msg)
 	local status, result =
 		pcall(gar.getPaginatedGateways, page.cursor, page.limit, page.sortBy or "startTimestamp", page.sortOrder)
@@ -1800,7 +1805,7 @@ Handlers.add("paginatedGateways", utils.hasMatchingTag("Action", "Paginated-Gate
 	end
 end)
 
-Handlers.add("paginatedBalances", utils.hasMatchingTag("Action", "Paginated-Balances"), function(msg)
+addEventingHandler("paginatedBalances", utils.hasMatchingTag("Action", "Paginated-Balances"), function(msg)
 	local page = utils.parsePaginationTags(msg)
 	local status, result =
 		pcall(balances.getPaginatedBalances, page.cursor, page.limit, page.sortBy or "balance", page.sortOrder)

--- a/src/main.lua
+++ b/src/main.lua
@@ -101,9 +101,8 @@ local function addRecordResultFields(ioEvent, result)
 	)
 	ioEvent:addFieldsIfExist(result.record, { "startTimestamp", "endTimestamp", "undernameLimit", "purchasePrice" })
 	if result.df ~= nil and type(result.df) == "table" then
-		-- TODO: provide array data rather than delimited strings
-		ioEvent:addField("DF-Trailing-Period-Purchases", table.concat(result.df.trailingPeriodPurchases or {}, ","))
-		ioEvent:addField("DF-Trailing-Period-Revenues", table.concat(result.df.trailingPeriodRevenues or {}, ","))
+		ioEvent:addField("DF-Trailing-Period-Purchases", (result.df.trailingPeriodPurchases or {}))
+		ioEvent:addField("DF-Trailing-Period-Revenues", (result.df.trailingPeriodRevenues or {}))
 		ioEvent:addFieldsWithPrefixIfExist(result.df, "DF-", {
 			"currentPeriod",
 			"currentDemandFactor",
@@ -169,22 +168,23 @@ end, function(msg)
 	if resultOrError ~= nil then
 		local prunedRecordsCount = #(resultOrError.prunedRecords or {})
 		if prunedRecordsCount > 0 then
-			-- TODO: provide array data rather than delimited string
-			msg.ioEvent:addField("Pruned-Records", table.concat(resultOrError.prunedRecords, ";"))
+			local prunedRecordNames = {}
+			for name, _ in pairs(resultOrError.prunedRecords) do
+				table.insert(prunedRecordNames, name)
+			end
+			msg.ioEvent:addField("Pruned-Records", prunedRecordNames)
 			msg.ioEvent:addField("Pruned-Records-Count", prunedRecordsCount)
 			msg.ioEvent:addField("Records-Count", utils.lengthOfTable(NameRegistry.records))
 		end
 		local prunedEpochsCount = #(resultOrError.prunedEpochs or {})
 		if prunedEpochsCount > 0 then
-			-- TODO: provide array data rather than delimited string
-			msg.ioEvent:addField("Pruned-Epochs", table.concat(resultOrError.prunedEpochs, ";"))
+			msg.ioEvent:addField("Pruned-Epochs", resultOrError.prunedEpochs)
 			msg.ioEvent:addField("Pruned-Epochs-Count", prunedEpochsCount)
 		end
 
 		local prunedGatewaysCount = #(resultOrError.prunedGateways or {})
 		if prunedGatewaysCount > 0 then
-			-- TODO: provide array data rather than delimited string
-			msg.ioEvent:addField("Pruned-Gateways", table.concat(msg.prunedGateways, ";"))
+			msg.ioEvent:addField("Pruned-Gateways", resultOrError.prunedGateways)
 			msg.ioEvent:addField("Pruned-Gateways-Count", prunedGatewaysCount)
 			local gwStats = gatewayStats()
 			msg.ioEvent:addField("Joined-Gateways-Count", gwStats.joined)
@@ -193,8 +193,7 @@ end, function(msg)
 
 		local slashedGatewaysCount = #(resultOrError.slashedGateways or {})
 		if slashedGatewaysCount > 0 then
-			-- TODO: provide array data rather than delimited string
-			msg.ioEvent:addField("Slashed-Gateways", table.concat(msg.slashedGateways, ";"))
+			msg.ioEvent:addField("Slashed-Gateways", resultOrError.slashedGateways)
 			msg.ioEvent:addField("Slashed-Gateways-Count", slashedGatewaysCount)
 		end
 	end
@@ -1414,23 +1413,19 @@ Handlers.add("distribute", utils.hasMatchingTag("Action", "Tick"), function(msg)
 		end
 	end
 	if #tickedEpochIndexes > 0 then
-		-- TODO: provide array data rather than delimited string
-		msg.ioEvent:addField("Ticked-Epoch-Indexes", table.concat(tickedEpochIndexes, ";"))
+		msg.ioEvent:addField("Ticked-Epoch-Indexes", tickedEpochIndexes)
 	end
 	if #newEpochIndexes > 0 then
-		-- TODO: provide array data rather than delimited string
-		msg.ioEvent:addField("New-Epoch-Indexes", table.concat(newEpochIndexes, ";"))
+		msg.ioEvent:addField("New-Epoch-Indexes", newEpochIndexes)
 		-- Only print the prescribed observers of the newest epoch
 		local newestEpoch = epochs.getEpoch(math.max(table.unpack(newEpochIndexes)))
 		local prescribedObserverAddresses = utils.map(newestEpoch.prescribedObservers, function(_, observer)
 			return observer.gatewayAddress
 		end)
-		-- TODO: provide array data rather than delimited string
-		msg.ioEvent:addField("Prescribed-Observers", table.concat(prescribedObserverAddresses, ";"))
+		msg.ioEvent:addField("Prescribed-Observers", prescribedObserverAddresses)
 	end
 	if #newDemandFactors > 0 then
-		-- TODO: provide array data rather than delimited string
-		msg.ioEvent:addField("New-Demand-Factors", table.concat(newDemandFactors, ";"))
+		msg.ioEvent:addField("New-Demand-Factors", newDemandFactors, ";")
 	end
 	msg.ioEvent:printEvent()
 end)

--- a/src/main.lua
+++ b/src/main.lua
@@ -824,7 +824,7 @@ addEventingHandler(ActionMap.LeaveNetwork, utils.hasMatchingTag("Action", Action
 	end
 
 	if gateway ~= nil then
-		msg.ioEvent:addField("GW-Vaults-Count", #(gateway.vaults or {}))
+		msg.ioEvent:addField("GW-Vaults-Count", utils.lengthOfTable(gateway.vaults or {}))
 		local exitVault = gateway.vaults[msg.From]
 		local withdrawVault = gateway.vaults[msg.Id]
 		local previousStake = exitVault.balance
@@ -954,7 +954,7 @@ addEventingHandler(
 			local previousStake = gateway.operatorStake + quantity
 			msg.ioEvent:addField("New-Operator-Stake", gateway.operatorStake)
 			msg.ioEvent:addField("Previous-Operator-Stake", previousStake)
-			msg.ioEvent:addField("GW-Vaults-Count", #(gateway.vaults or {}))
+			msg.ioEvent:addField("GW-Vaults-Count", utils.lengthOfTable(gateway.vaults or {}))
 			local decreaseStakeVault = gateway.vaults[msg.Id]
 			if decreaseStakeVault ~= nil then
 				previousStake = previousStake + decreaseStakeVault.balance
@@ -1238,11 +1238,13 @@ addEventingHandler(ActionMap.SaveObservations, utils.hasMatchingTag("Action", Ac
 	end
 
 	if observations ~= nil then
-		if #(observations.failureSummaries or {}) > 0 then
-			msg.ioEvent:addField("Failure-Summaries-Count", #(observations.failureSummaries or {}))
+		local failureSummariesCount = utils.lengthOfTable(observations.failureSummaries or {})
+		if failureSummariesCount > 0 then
+			msg.ioEvent:addField("Failure-Summaries-Count", failureSummariesCount)
 		end
-		if #(observations.reports or {}) > 0 then
-			msg.ioEvent:addField("Reports-Count", #(observations.reports or {}))
+		local reportsCount = utils.lengthOfTable(observations.reports or {})
+		if reportsCount > 0 then
+			msg.ioEvent:addField("Reports-Count", reportsCount)
 		end
 	end
 

--- a/tests/arns.test.mjs
+++ b/tests/arns.test.mjs
@@ -63,6 +63,22 @@ describe('ArNS', async () => {
     );
 
     const buyRecordData = JSON.parse(buyRecordResult.Messages[0].Data);
+    const buyRecordEvent = JSON.parse(buyRecordResult.Output.data.split('\n')[1]);
+    
+    // Fields based on timestamps will be unstable for testing, but verify their type
+    assert.equal("number", typeof buyRecordEvent.Timestamp);
+    assert.equal("number", typeof buyRecordEvent['Epoch-Index']);
+    assert.equal("number", typeof buyRecordEvent['Start-Timestamp']);
+    assert.equal("number", typeof buyRecordEvent['End-Timestamp']);
+    delete buyRecordEvent.Timestamp;
+    delete buyRecordEvent['Epoch-Index'];
+    delete buyRecordEvent['Start-Timestamp'];
+    delete buyRecordEvent['End-Timestamp'];
+    const expectedRemainingBalance = {
+      "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa": 0,
+      "1111111111111111111111111111111111111111111": 950000000000000,
+    }
+    assert.deepEqual(buyRecordEvent, { _e: 1, 'Purchase-Type': 'lease', 'DF-Purchases-This-Period': 1, 'DF-Revenue-This-Period': 600000000, 'DF-Current-Demand-Factor': 1, Action: 'Buy-Record', 'Name-Length': 9, 'Purchase-Price': 600000000, 'Base-Registration-Fee': 500000000, 'DF-Current-Period': 1, 'DF-Trailing-Period-Revenues': [0,0,0,0,0,0], 'DF-Trailing-Period-Purchases': [0,0,0,0,0,0,0], Cron: false, Cast: false, 'Undername-Limit': 10, Name: 'test-name', Years: '1', 'DF-Consecutive-Periods-With-Min-Demand-Factor': 0, 'Process-Id': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', From: sender, 'From-Formatted': sender, 'Message-Id': '1111111111111111111111111111111111111111111', 'Records-Count': 1, 'Protocol-Balance': 950000000000000, 'Reserved-Records-Count': 0, 'Remaining-Balance': expectedRemainingBalance[sender] });
 
     // fetch the record
     const realRecord = await handle(


### PR DESCRIPTION
- Collect event info for every handler by using a wrapper function
- No longer print events in eventingPcall; expect wrapper function to handle
- Repair collection of event data for a few tables