### PR TITLE
PE-6976: instant withdraw event data

### DIFF
--- a/src/constants.lua
+++ b/src/constants.lua
@@ -7,8 +7,8 @@ constants.oneYearSeconds = 60 * 60 * 24 * 365
 constants.thirtyDaysSeconds = 60 * 60 * 24 * 30
 constants.defaultundernameLimit = 10
 constants.totalTokenSupply = 1000000000 * 1000000 -- 1 billion tokens
-constants.MIN_EXPEDITED_WITHDRAWAL_FEE = 0.05
-constants.MAX_EXPEDITED_WITHDRAWAL_FEE = 0.80
+constants.MIN_EXPEDITED_WITHDRAWAL_PENALTY_RATE = 0.05
+constants.MAX_EXPEDITED_WITHDRAWAL_PENALTY_RATE = 0.80
 
 -- ARNS
 constants.DEFAULT_UNDERNAME_COUNT = 10

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -380,11 +380,11 @@ function gar.decreaseDelegateStake(gatewayAddress, delegator, qty, currentTimest
 		gateway.totalDelegatedStake = gateway.totalDelegatedStake - qty
 
 		-- Calculate the penalty amount
-		local expenditedWithdrawalFee = qty * constants.MAX_EXPEDITED_WITHDRAWAL_FEE
-		local amountToWithdraw = qty - expenditedWithdrawalFee
+		local expeditedWithdrawalFee = qty * constants.MAX_EXPEDITED_WITHDRAWAL_FEE
+		local amountToWithdraw = qty - expeditedWithdrawalFee
 
 		-- Add penalty to AR.IO protocol balance
-		balances.increaseBalance(ao.id, expenditedWithdrawalFee)
+		balances.increaseBalance(ao.id, expeditedWithdrawalFee)
 
 		-- Withdraw the remaining tokens to the delegate
 		balances.increaseBalance(delegator, amountToWithdraw)

--- a/src/main.lua
+++ b/src/main.lua
@@ -1326,7 +1326,7 @@ addEventingHandler(
 			msg.ioEvent:addField("Vault-Elapsed-Time", result.elapsedTime)
 			msg.ioEvent:addField("Vault-Remaining-Time", result.remainingTime)
 			msg.ioEvent:addField("Penalty-Rate", result.penaltyRate)
-			msg.ioEvent:addField("Expedited-Withdrawal-Fee", result.expeditedWithdrawalFee)
+			msg.ioEvent:addField("Instant-Withdrawal-Fee", result.expeditedWithdrawalFee)
 			msg.ioEvent:addField("Amount-Withdrawn", result.amountWithdrawn)
 			msg.ioEvent:addField("Previous-Vault-Balance", result.amountWithdrawn + result.expeditedWithdrawalFee)
 			lastKnownCirculatingSupply = lastKnownCirculatingSupply + result.amountWithdrawn

--- a/src/main.lua
+++ b/src/main.lua
@@ -1428,7 +1428,9 @@ addEventingHandler(
 		end
 
 		lastKnownDelegatedSupply = lastKnownDelegatedSupply - quantity
-		lastKnownWithdrawSupply = lastKnownWithdrawSupply + quantity - amountWithdrawn
+		if not instantWithdraw then
+			lastKnownWithdrawSupply = lastKnownWithdrawSupply + quantity
+		end
 		lastKnownCirculatingSupply = lastKnownCirculatingSupply + amountWithdrawn
 		addSupplyData(msg.ioEvent)
 


### PR DESCRIPTION
- Corrected spelling of `expendited` -> `expedited` everywhere necessary
- Updated constant names from `FEE` to `RATE` where sensible
- Modified redundant unit test for instant delegate withdrawals to the max duration (non-invariant boundary case)
- Collected penalty rate and fee information for event data on instant withdrawals