### PR TITLE
PE-7034: fix errors

### DIFF
--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -1662,6 +1662,7 @@ describe("gar", function()
 					delegatedStake = 1000,
 					vaults = {},
 				},
+				vaultBalance = 1000,
 			})
 			-- assert the vault is removed and the delegated stake is added back to the delegate
 			assert.are.equal(

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -788,6 +788,7 @@ function gar.cancelDelegateWithdrawal(from, gatewayAddress, vaultId)
 	return {
 		delegate = gar.getGateway(gatewayAddress).delegates[from],
 		totalDelegatedStake = gateway.totalDelegatedStake,
+		vaultBalance = vaultBalance,
 	}
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -816,8 +816,8 @@ addEventingHandler(
 			recordResult = result.record
 			addRecordResultFields(msg.ioEvent, result)
 			msg.ioEvent:addField("previousUndernameLimit", recordResult.undernameLimit - tonumber(msg.Tags.Quantity))
-			msg.ioEvent:addField("additionalUndernameCost", recordResult.additionalUndernameCost)
-			LastKnownCirculatingSupply = LastKnownCirculatingSupply - recordResult.additionalUndernameCost
+			msg.ioEvent:addField("additionalUndernameCost", result.additionalUndernameCost)
+			LastKnownCirculatingSupply = LastKnownCirculatingSupply - result.additionalUndernameCost
 			addSupplyData(msg.ioEvent)
 		end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -753,11 +753,13 @@ addEventingHandler(ActionMap.ExtendLease, utils.hasMatchingTag("Action", ActionM
 
 	local recordResult = {}
 	if result ~= nil then
-		recordResult = result.record
+		msg.ioEvent:addField("Total-Extension-Fee", result.totalExtensionFee)
 		addRecordResultFields(msg.ioEvent, result)
-		msg.ioEvent:addField("totalExtensionFee", recordResult.totalExtensionFee)
-		LastKnownCirculatingSupply = LastKnownCirculatingSupply - recordResult.totalExtensionFee
+
+		LastKnownCirculatingSupply = LastKnownCirculatingSupply - result.totalExtensionFee
 		addSupplyData(msg.ioEvent)
+
+		recordResult = result.record
 	end
 
 	ao.send({

--- a/src/main.lua
+++ b/src/main.lua
@@ -795,7 +795,7 @@ addEventingHandler(
 		end
 
 		local shouldContinue2, result = eventingPcall(
-			ioEvent,
+			msg.ioEvent,
 			function(error)
 				ao.send({
 					Target = msg.From,

--- a/src/main.lua
+++ b/src/main.lua
@@ -1201,7 +1201,7 @@ addEventingHandler(ActionMap.DelegateStake, utils.hasMatchingTag("Action", Actio
 	end
 
 	LastKnownCirculatingSupply = LastKnownCirculatingSupply - quantity
-	LastKnownStakedSupply = LastKnownStakedSupply + quantity
+	LastKnownDelegatedSupply = LastKnownDelegatedSupply + quantity
 	addSupplyData(msg.ioEvent)
 
 	ao.send({
@@ -1255,12 +1255,12 @@ addEventingHandler(
 			if result.delegate ~= nil then
 				delegateResult = result.delegate
 				local newStake = delegateResult.delegatedStake
-				local vaultBalance = delegateResult.vaults[vaultId].balance
-				msg.ioEvent:addField("PreviousStake", newStake - vaultBalance)
-				msg.ioEvent:addField("NewStake", newStake)
-				msg.ioEvent:addField("GatewayTotalDelegatedStake", result.totalDelegatedStake)
+				local vaultBalance = result.vaultBalance
+				msg.ioEvent:addField("Previous-Stake", newStake - vaultBalance)
+				msg.ioEvent:addField("New-Stake", newStake)
+				msg.ioEvent:addField("Gateway-Total-Delegated-Stake", result.totalDelegatedStake)
 
-				LastKnownStakedSupply = LastKnownStakedSupply + vaultBalance
+				LastKnownDelegatedSupply = LastKnownDelegatedSupply + vaultBalance
 				LastKnownWithdrawSupply = LastKnownWithdrawSupply - vaultBalance
 				addSupplyData(msg.ioEvent)
 			end


### PR DESCRIPTION
Fixes for the following errors:

- Cancel-Delegate-Withdrawal: [string "aos"]:15425: attempt to index a nil value (field '?')
- Increase-Undername-Limit | [string "aos"]:14987: attempt to perform arithmetic on a nil value (field 'additionalUndernameCost')
- Increase-Undername-Limit | [string "aos"]:14247: attempt to index a nil value (local 'ioEvent')
- Extend-Lease | [string "aos"]:14926: attempt to perform arithmetic on a nil value (field 'totalExtensionFee')





