### PR TITLE
PE-7035: track discovery of records entering their grace period

### DIFF
--- a/src/arns.lua
+++ b/src/arns.lua
@@ -691,6 +691,7 @@ end
 
 --- Prunes records that have expired
 --- @param currentTimestamp number The current timestamp
+--- @param lastGracePeriodEntryEndTimestamp number The end timestamp of the last known record to have entered its grace period
 --- @return table The pruned records
 function arns.pruneRecords(currentTimestamp, lastGracePeriodEntryEndTimestamp)
 	lastGracePeriodEntryEndTimestamp = lastGracePeriodEntryEndTimestamp or 0

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -692,7 +692,8 @@ end
 --- Prunes records that have expired
 --- @param currentTimestamp number The current timestamp
 --- @param lastGracePeriodEntryEndTimestamp number The end timestamp of the last known record to have entered its grace period
---- @return table The pruned records
+--- @return table # The pruned records
+--- @return number # The end timestamp of the last known record to have entered its grace period
 function arns.pruneRecords(currentTimestamp, lastGracePeriodEntryEndTimestamp)
 	lastGracePeriodEntryEndTimestamp = lastGracePeriodEntryEndTimestamp or 0
 	local prunedRecords = {}

--- a/src/tick.lua
+++ b/src/tick.lua
@@ -8,8 +8,8 @@ local epochs = require("epochs")
 --- @param timestamp number The timestamp
 --- @param msgId string The message ID
 --- @return table The pruned records, auctions, reserved names, vaults, gateways, and epochs
-function tick.pruneState(timestamp, msgId)
-	local prunedRecords = arns.pruneRecords(timestamp)
+function tick.pruneState(timestamp, msgId, lastGracePeriodEntryEndTimestamp)
+	local prunedRecords, newGracePeriodRecords = arns.pruneRecords(timestamp, lastGracePeriodEntryEndTimestamp)
 	local prunedAuctions = arns.pruneAuctions(timestamp)
 	local prunedReserved = arns.pruneReservedNames(timestamp)
 	local prunedVaults = vaults.pruneVaults(timestamp)
@@ -17,6 +17,7 @@ function tick.pruneState(timestamp, msgId)
 	local prunedEpochs = epochs.pruneEpochs(timestamp)
 	return {
 		prunedRecords = prunedRecords,
+		newGracePeriodRecords = newGracePeriodRecords,
 		prunedAuctions = prunedAuctions,
 		prunedReserved = prunedReserved,
 		prunedVaults = prunedVaults,

--- a/src/tick.lua
+++ b/src/tick.lua
@@ -7,6 +7,7 @@ local epochs = require("epochs")
 --- Prunes the state
 --- @param timestamp number The timestamp
 --- @param msgId string The message ID
+--- @param lastGracePeriodEntryEndTimestamp number The end timestamp of the last known record to enter grace period
 --- @return table The pruned records, auctions, reserved names, vaults, gateways, and epochs
 function tick.pruneState(timestamp, msgId, lastGracePeriodEntryEndTimestamp)
 	local prunedRecords, newGracePeriodRecords = arns.pruneRecords(timestamp, lastGracePeriodEntryEndTimestamp)


### PR DESCRIPTION
We can only discover records entering the grace period by looking for them on every message. Fortunately, pruning looks at every record during every message, so we can find them during that process. Additionally, once a record enters the grace period, we don't want to see it in event data again, so we'll keep a global record of the end timestamp of the last record end timestamp we saw in event data, and then will only add event data for records in the grace period in subsequent events if their end timestamp is after the largest last known end timestamp value.