### PR TITLE
fix(gar): autoStake all delegate rewards

### DIFF
--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -53,7 +53,7 @@ describe("epochs", function()
 
 	describe("computePrescribedObserversForEpoch", function()
 		it("should return all eligible gateways if fewer than the maximum in network", function()
-			GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"] = {
+			_G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -121,7 +121,7 @@ describe("epochs", function()
 					observerAddress = "observerAddress",
 				}
 				-- note - ordering of keys is not guaranteed when insert into maps
-				GatewayRegistry["observer" .. i] = gateway
+				_G.GatewayRegistry["observer" .. i] = gateway
 			end
 
 			local expectation = {

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -563,7 +563,7 @@ describe("epochs", function()
 	end)
 
 	describe("distributeRewardsForEpoch", function()
-		it("should distribute rewards for the epoch", function()
+		it("should distribute rewards for the epoch, auto staking for delegates", function()
 			_G.Epochs[0] = {
 				epochIndex = 0,
 				observations = {
@@ -684,14 +684,15 @@ describe("epochs", function()
 			}
 
 			local epochIndex = 0
+			local originalDelegatedStake = 100000000
 			for i = 1, 5 do
 				local gateway = {
 					operatorStake = gar.getSettings().operators.minStake,
-					totalDelegatedStake = 100000000,
+					totalDelegatedStake = originalDelegatedStake,
 					vaults = {},
 					delegates = {
 						["this-is-a-delegate"] = {
-							delegatedStake = 100000000,
+							delegatedStake = originalDelegatedStake,
 							startTimestamp = 0,
 							vaults = {},
 						},
@@ -820,34 +821,48 @@ describe("epochs", function()
 				gar.getGateway("test-this-is-valid-arweave-wallet-address-5").operatorStake
 			)
 
+			local expectedGateway1TotalRewards = 0
+			local expectedGateway2TotalRewards = math.floor(expectedGatewayReward * 0.75) -- penalized for not observing
+			local expectedGateway3TotalRewards = expectedObserverReward
+			local expectedGateway4TotalRewards = (expectedGatewayReward + expectedObserverReward)
+			local expectedGateway5TotalRewards = (expectedGatewayReward + expectedObserverReward)
+
 			-- check the epoch was updated
 			local distributions = epochs.getEpoch(epochIndex).distributions
-			local expectedTotalDistribution = 0 -- gateway 1 did not get any rewards
-				+ math.floor(expectedGatewayReward * 0.75) -- gateway 2 got 75% of the gateway reward
-				+ expectedObserverReward * 3 -- gateway 3, 4, 5 got observer rewards
-				+ expectedGatewayReward * 2 -- gateway 4, 5 got gateway rewards
-
-			local distributedEpoch = epochs.getEpoch(epochIndex)
+			local expectedTotalDistribution = math.floor(expectedGateway1TotalRewards + expectedGateway2TotalRewards + expectedGateway3TotalRewards + expectedGateway4TotalRewards + expectedGateway5TotalRewards)
 
 			-- confirm the updated epoch values
 			assert.are.equal(expectedTotalDistribution, distributions.totalDistributedRewards)
 			assert.are.equal(epoch.distributionTimestamp, distributions.distributedTimestamp)
 
 			assert.are.same({
-				["test-this-is-valid-arweave-wallet-address-1"] = 0,
-				["test-this-is-valid-arweave-wallet-address-2"] = math.floor(expectedGatewayReward * 0.75 * 0.90),
-				["test-this-is-valid-arweave-wallet-address-3"] = expectedObserverReward * 0.90,
-				["test-this-is-valid-arweave-wallet-address-4"] = (expectedGatewayReward + expectedObserverReward)
-					* 0.90,
-				["test-this-is-valid-arweave-wallet-address-5"] = (expectedGatewayReward + expectedObserverReward)
-					* 0.90,
-				-- the delegate that got rewards
-				["this-is-a-delegate"] = math.floor(
-					(expectedGatewayReward * 0.10 * 2) -- recevied by two passing gateways
-						+ (expectedGatewayReward * 0.10 * 0.75) -- recevied by one passing gateway that did not observe
-						+ (expectedObserverReward * 0.10 * 3) -- recevied by three observer gateways
-				),
+				["test-this-is-valid-arweave-wallet-address-1"] = expectedGateway1TotalRewards * 0.90,
+				["test-this-is-valid-arweave-wallet-address-2"] = expectedGateway2TotalRewards * 0.90,
+				["test-this-is-valid-arweave-wallet-address-3"] = expectedGateway3TotalRewards * 0.90,
+				["test-this-is-valid-arweave-wallet-address-4"] = expectedGateway4TotalRewards * 0.90,
+				["test-this-is-valid-arweave-wallet-address-5"] = expectedGateway5TotalRewards * 0.90,
+				["this-is-a-delegate"] = expectedTotalDistribution * 0.10,
 			}, distributions.rewards.distributed)
+			-- gateway 1 did not get any rewards, so the delegate stake should be the original amount
+			assert.are.equal(
+				originalDelegatedStake,
+				gar.getGateway("test-this-is-valid-arweave-wallet-address-1").delegates["this-is-a-delegate"].delegatedStake
+			)
+			-- delegate on gateway 2 gets 10% of the total rewards received by the gateway
+			assert.are.equal(
+				originalDelegatedStake + math.floor(expectedGateway2TotalRewards * 0.10),
+				gar.getGateway("test-this-is-valid-arweave-wallet-address-2").delegates["this-is-a-delegate"].delegatedStake
+			)
+			-- delegate on gateway 3 gets 10% of the total rewards received by the gateway
+			assert.are.equal(
+				originalDelegatedStake + math.floor(expectedGateway3TotalRewards * 0.10),
+				gar.getGateway("test-this-is-valid-arweave-wallet-address-3").delegates["this-is-a-delegate"].delegatedStake
+			)
+			-- delegate on gateway 4 gets 10% of the total rewards received by the gateway
+			assert.are.equal(
+				originalDelegatedStake + math.floor(expectedGateway4TotalRewards * 0.10),
+				gar.getGateway("test-this-is-valid-arweave-wallet-address-4").delegates["this-is-a-delegate"].delegatedStake
+			)
 			-- assert that the balance withdrawn from the protocol balance matches the total distributed rewards
 			assert.are.equal(protocolBalance - expectedTotalDistribution, balances.getBalance(ao.id))
 		end)

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -730,8 +730,8 @@ describe("epochs", function()
 			local expectedObserverReward = epoch.distributions.totalEligibleObserverReward
 
 			-- distribute rewards for the epoch
-			local status = pcall(epochs.distributeRewardsForEpoch, epoch.distributionTimestamp)
-			assert.is_true(status)
+			local result = epochs.distributeRewardsForEpoch(epoch.distributionTimestamp)
+			assert.is_not_nil(result)
 			-- gateway 1 should not get any rewards - failed observation and did not observe, should not get any rewards
 			assert.are.same({
 				prescribedEpochCount = 2, -- increment by one

--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -583,7 +583,7 @@ describe("gar", function()
 
 	describe("leaveNetwork", function()
 		it("should leave the network", function()
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = (gar.getSettings().operators.minStake + 1000),
 				totalDelegatedStake = gar.getSettings().delegates.minStake,
 				vaults = {},
@@ -660,7 +660,7 @@ describe("gar", function()
 	describe("increaseOperatorStake", function()
 		it("should increase operator stake", function()
 			Balances[stubGatewayAddress] = 1000
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1012,7 +1012,7 @@ describe("gar", function()
 
 	describe("updateGatewaySettings", function()
 		it("should update gateway settings", function()
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1078,7 +1078,7 @@ describe("gar", function()
 		end)
 
 		it("should allow updating gateway services", function()
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1137,7 +1137,7 @@ describe("gar", function()
 		end)
 
 		it("should not allow editing of gateway settings for a gateway that is leaving", function()
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1202,7 +1202,7 @@ describe("gar", function()
 	describe("delegateStake", function()
 		it("should delegate stake to a gateway", function()
 			Balances[stubRandomAddress] = gar.getSettings().delegates.minStake
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1258,7 +1258,7 @@ describe("gar", function()
 		end)
 
 		it("should decrease delegated stake", function()
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = gar.getSettings().delegates.minStake + 1000,
 				vaults = {},
@@ -1332,7 +1332,7 @@ describe("gar", function()
 			Balances[ao.id] = 0
 			local expeditedWithdrawalFee = 1000 * 0.50
 			local withdrawalAmount = 1000 - expeditedWithdrawalFee
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = gar.getSettings().delegates.minStake + 1000,
 				vaults = {},
@@ -1396,7 +1396,7 @@ describe("gar", function()
 
 		it("should error if the remaining delegate stake is less than the minimum stake", function()
 			local delegatedStake = gar.getSettings().delegates.minStake
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = gar.getSettings().delegates.minStake - 1,
 				vaults = {},
@@ -1741,7 +1741,7 @@ describe("gar", function()
 		it("should slash operator stake by the provided slash amount and return it to the protocol balance", function()
 			local slashAmount = 10000
 			Balances[ao.id] = 0
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1752,7 +1752,7 @@ describe("gar", function()
 			assert.is_nil(err)
 			assert.are.equal(
 				gar.getSettings().operators.minStake - slashAmount,
-				GatewayRegistry[stubGatewayAddress].operatorStake
+				_G.GatewayRegistry[stubGatewayAddress].operatorStake
 			)
 			assert.are.equal(slashAmount, Balances[ao.id])
 		end)
@@ -1760,7 +1760,7 @@ describe("gar", function()
 
 	describe("getGatewayWeightsAtTimestamp", function()
 		it("shoulud properly compute weights based on gateways for a given timestamp", function()
-			GatewayRegistry[stubGatewayAddress] = {
+			_G.GatewayRegistry[stubGatewayAddress] = {
 				operatorStake = gar.getSettings().operators.minStake,
 				totalDelegatedStake = 0,
 				vaults = {},
@@ -1876,25 +1876,25 @@ describe("gar", function()
 				}, result)
 
 				local expectedRemainingStake = math.floor(gar.getSettings().operators.minStake * 0.8) + 10000
-				assert.is_nil(GatewayRegistry["address1"]) -- removed
-				assert.is_not_nil(GatewayRegistry["address2"]) -- not removed
-				assert.is_not_nil(GatewayRegistry["address3"]) -- not removed
+				assert.is_nil(_G.GatewayRegistry["address1"]) -- removed
+				assert.is_not_nil(_G.GatewayRegistry["address2"]) -- not removed
+				assert.is_not_nil(_G.GatewayRegistry["address3"]) -- not removed
 				-- Check that gateway 3's operator stake is slashed by 20% and the remaining stake is vaulted
-				assert.are.equal("leaving", GatewayRegistry["address3"].status)
-				assert.are.equal(0, GatewayRegistry["address3"].operatorStake)
+				assert.are.equal("leaving", _G.GatewayRegistry["address3"].status)
+				assert.are.equal(0, _G.GatewayRegistry["address3"].operatorStake)
 				assert.are.same({
 					balance = expectedRemainingStake,
 					startTimestamp = currentTimestamp,
 					endTimestamp = currentTimestamp + gar.getSettings().operators.leaveLengthMs,
-				}, GatewayRegistry["address3"].vaults["address3"])
+				}, _G.GatewayRegistry["address3"].vaults["address3"])
 				assert.are.equal(protocolBalanceBefore + expectedSlashedStake, Balances[ao.id])
 			end
 		)
 
-		it("should handle empty GatewayRegistry", function()
+		it("should handle empty _G.GatewayRegistry", function()
 			local currentTimestamp = 1000000
 
-			-- Set up empty GatewayRegistry
+			-- Set up empty _G.GatewayRegistry
 			_G.GatewayRegistry = {}
 
 			-- Call pruneGateways
@@ -1937,13 +1937,13 @@ describe("gar", function()
 			-- assert the vault is removed and the delegated stake is added back to the delegate
 			assert.are.equal(
 				1000, -- added back to the delegate
-				GatewayRegistry[stubGatewayAddress].delegates[stubRandomAddress].delegatedStake
+				_G.GatewayRegistry[stubGatewayAddress].delegates[stubRandomAddress].delegatedStake
 			)
 			assert.are.equal(
 				nil,
-				GatewayRegistry[stubGatewayAddress].delegates[stubRandomAddress].vaults["some-previous-withdrawal-id"]
+				_G.GatewayRegistry[stubGatewayAddress].delegates[stubRandomAddress].vaults["some-previous-withdrawal-id"]
 			)
-			assert.are.equal(1000, GatewayRegistry[stubGatewayAddress].totalDelegatedStake)
+			assert.are.equal(1000, _G.GatewayRegistry[stubGatewayAddress].totalDelegatedStake)
 		end)
 		it("should not cancel a withdrawal if the gateway does not allow staking", function()
 			_G.GatewayRegistry[stubGatewayAddress] = testGateway
@@ -2090,21 +2090,25 @@ describe("gar", function()
 	-- 			},
 	-- 		}
 	-- 		local result = gar.getActiveGatewaysBeforeTimestamp(timestamp)
-	-- 		assert.are.same({ stubGatewayAddress, stubRandomAddress }, result)
+	-- 		-- assert both gateways are returned, in no particular ordering
+	-- 		assert.is_true(utils.isSubset(result, {
+	-- 			[stubGatewayAddress] = testGateway,
+	-- 			[stubRandomAddress] = testGateway,
+	-- 		}))
 	-- 	end)
 	-- end)
 
 	describe("getters", function()
 		-- TODO: other tests for error conditions when joining/leaving network
 		it("should get single gateway", function()
-			GatewayRegistry[stubGatewayAddress] = testGateway
+			_G.GatewayRegistry[stubGatewayAddress] = testGateway
 			local result = gar.getGateway(stubGatewayAddress)
 			assert.are.same(result, testGateway)
 		end)
 
 		it("should get multiple gateways", function()
-			GatewayRegistry[stubGatewayAddress] = testGateway
-			GatewayRegistry[stubRandomAddress] = testGateway
+			_G.GatewayRegistry[stubGatewayAddress] = testGateway
+			_G.GatewayRegistry[stubRandomAddress] = testGateway
 			local result = gar.getGateways()
 			assert.are.same(result, {
 				[stubGatewayAddress] = testGateway,

--- a/src/balances.lua
+++ b/src/balances.lua
@@ -5,6 +5,11 @@ Balances = Balances or {}
 local balances = {}
 local utils = require("utils")
 
+--- Transfers tokens from one address to another
+---@param recipient string The address to receive tokens
+---@param from string The address sending tokens
+---@param qty number The amount of tokens to transfer (must be integer)
+---@return table Updated balances for sender and recipient addresses
 function balances.transfer(recipient, from, qty)
 	assert(type(recipient) == "string", "Recipient is required!")
 	assert(type(from) == "string", "From is required!")
@@ -20,15 +25,24 @@ function balances.transfer(recipient, from, qty)
 	}
 end
 
+--- Gets the balance for a specific address
+---@param target string The address to get balance for
+---@return number The balance amount (0 if address has no balance)
 function balances.getBalance(target)
-	return utils.deepCopy(Balances[target] or 0)
+	return Balances[target] or 0
 end
 
+--- Gets all balances in the system
+---@return table All address:balance pairs
 function balances.getBalances()
-	local balances = utils.deepCopy(Balances)
-	return balances or {}
+	local balances = utils.deepCopy(Balances) or {}
+	return balances
 end
 
+--- Reduces the balance of an address
+---@param target string The address to reduce balance for
+---@param qty number The amount to reduce by (must be integer)
+---@throws error If target has insufficient balance
 function balances.reduceBalance(target, qty)
 	local prevBalance = balances.getBalance(target)
 	if prevBalance < qty then
@@ -38,12 +52,21 @@ function balances.reduceBalance(target, qty)
 	Balances[target] = prevBalance - qty
 end
 
+--- Increases the balance of an address
+---@param target string The address to increase balance for
+---@param qty number The amount to increase by (must be integer)
 function balances.increaseBalance(target, qty)
 	assert(utils.isInteger(qty), debug.traceback("Quantity must be an integer: " .. qty))
 	local prevBalance = balances.getBalance(target) or 0
 	Balances[target] = prevBalance + qty
 end
 
+--- Gets paginated list of all balances
+---@param cursor string|nil The address to start from
+---@param limit number|nil Max number of results to return
+---@param sortBy string|nil Field to sort by
+---@param sortOrder string|nil "asc" or "desc" sort direction
+---@return table Array of {address, balance} objects
 function balances.getPaginatedBalances(cursor, limit, sortBy, sortOrder)
 	local balances = balances.getBalances()
 	local balancesArray = {}

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -539,8 +539,8 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 					or gateway.stats.observedEpochCount,
 			}
 
-			-- update the gateway stats
-			gar.updateGatewayStats(gatewayAddress, updatedStats)
+			-- update the gateway stats, returns the updated gateway
+			gateway = gar.updateGatewayStats(gatewayAddress, gateway, updatedStats)
 
 			-- scenarioes
 			-- 1. Gateway passed and was prescribed and submittied an observation - it gets full gateway reward
@@ -587,7 +587,7 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 					-- distribute the rewards to the delegate if greater than 0
 					if actualDelegateReward > 0 then
 						-- increase the stake and decrease the protocol balance
-						gar.increaseExistingDelegateStake(gatewayAddress, delegateAddress, actualDelegateReward)
+						gar.increaseExistingDelegateStake(gatewayAddress, gateway, delegateAddress, actualDelegateReward)
 						balances.reduceBalance(ao.id, actualDelegateReward)
 					end
 					-- increment the total distributed

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -586,7 +586,9 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 					local actualDelegateReward = math.floor(eligibleDelegateReward * percentOfEligibleEarned)
 					-- distribute the rewards to the delegate if greater than 0
 					if actualDelegateReward > 0 then
-						balances.transfer(delegateAddress, ao.id, actualDelegateReward)
+						-- increase the stake and decrease the protocol balance
+						gar.increaseExistingDelegateStake(gatewayAddress, delegateAddress, actualDelegateReward)
+						balances.reduceBalance(ao.id, actualDelegateReward)
 					end
 					-- increment the total distributed
 					totalDistributed = math.floor(totalDistributed + actualDelegateReward)

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -586,8 +586,13 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 					local actualDelegateReward = math.floor(eligibleDelegateReward * percentOfEligibleEarned)
 					-- distribute the rewards to the delegate if greater than 0
 					if actualDelegateReward > 0 then
-						-- increase the stake and decrease the protocol balance
-						gar.increaseExistingDelegateStake(gatewayAddress, gateway, delegateAddress, actualDelegateReward)
+						-- increase the stake and decrease the protocol balance, returns the updated gateway
+						gateway = gar.increaseExistingDelegateStake(
+							gatewayAddress,
+							gateway,
+							delegateAddress,
+							actualDelegateReward
+						)
 						balances.reduceBalance(ao.id, actualDelegateReward)
 					end
 					-- increment the total distributed

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -384,9 +384,16 @@ end
 
 function gar.increaseExistingDelegateStake(gatewayAddress, delegateAddress, qty)
 	local gateway = gar.getGateway(gatewayAddress)
-
 	if not gateway then
 		error("Gateway not found")
+	end
+
+	if not delegateAddress then
+		error("Delegate address is required")
+	end
+
+	if not qty or not utils.isInteger(qty) or qty <= 0 then
+		error("Quantity is required and must be an integer greater than 0: " .. qty)
 	end
 
 	local delegate = gateway.delegates[delegateAddress]

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -10,7 +10,7 @@ GatewayRegistrySettings = GatewayRegistrySettings
 		observers = {
 			maxPerEpoch = 50,
 			tenureWeightDays = 180,
-			tenureWeightPeriod = 180 * 24 * 60 * 60 * 1000, -- aproximately 2 years
+			tenureWeightPeriod = 180 * 24 * 60 * 60 * 1000, -- aproximately 180 days
 			maxTenureWeight = 4,
 		},
 		operators = {
@@ -306,11 +306,15 @@ function gar.updateGatewaySettings(from, updatedSettings, updatedServices, obser
 	return gar.getGateway(from)
 end
 
+--- Gets a gateway by address
+---@param address string The address to get the gateway for
+---@return table|nil The gateway object or nil if not found
 function gar.getGateway(address)
-	local gateway = utils.deepCopy(GatewayRegistry[address])
-	return gateway
+	return utils.deepCopy(GatewayRegistry[address])
 end
 
+--- Gets all gateways
+---@return table All gateway objects
 function gar.getGateways()
 	local gateways = utils.deepCopy(GatewayRegistry)
 	return gateways or {}
@@ -382,8 +386,12 @@ function gar.delegateStake(from, target, qty, currentTimestamp)
 	return gar.getGateway(target)
 end
 
-function gar.increaseExistingDelegateStake(gatewayAddress, delegateAddress, qty)
-	local gateway = gar.getGateway(gatewayAddress)
+--- Internal function to increase the stake of an existing delegate. This should only be called from epochs.lua
+---@param gatewayAddress string # The gateway address to increase stake for (required)
+---@param gateway table # The gateway object to increase stake for (required)
+---@param delegateAddress string # The address of the delegate to increase stake for (required)
+---@param qty number # The amount of stake to increase by - must be positive integer (required)
+function gar.increaseExistingDelegateStake(gatewayAddress, gateway, delegateAddress, qty)
 	if not gateway then
 		error("Gateway not found")
 	end
@@ -404,7 +412,7 @@ function gar.increaseExistingDelegateStake(gatewayAddress, delegateAddress, qty)
 	gateway.delegates[delegateAddress].delegatedStake = delegate.delegatedStake + qty
 	gateway.totalDelegatedStake = gateway.totalDelegatedStake + qty
 	GatewayRegistry[gatewayAddress] = gateway
-	return gar.getGateway(gatewayAddress)
+	return gateway
 end
 
 function gar.getSettings()
@@ -662,8 +670,11 @@ function gar.assertValidGatewayParameters(from, stake, settings, services, obser
 	end
 end
 
-function gar.updateGatewayStats(address, stats)
-	local gateway = gar.getGateway(address)
+--- Updates the stats for a gateway
+---@param address string # The address of the gateway to update stats for
+---@param gateway table # The gateway object to update stats for
+---@param stats table # The stats to update the gateway with
+function gar.updateGatewayStats(address, gateway, stats)
 	if gateway == nil then
 		error("Gateway not found")
 	end
@@ -678,6 +689,7 @@ function gar.updateGatewayStats(address, stats)
 
 	gateway.stats = stats
 	GatewayRegistry[address] = gateway
+	return gateway
 end
 
 function gar.updateGatewayWeights(weightedGateway)

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -135,11 +135,13 @@ function gar.leaveNetwork(from, currentTimestamp, msgId)
 	return gateway
 end
 
+--- Increases the operator stake for a gateway
+---@param from string # The address of the gateway to increase stake for
+---@param qty number # The amount of stake to increase by - must be positive integer
+---@return table # The updated gateway object
 function gar.increaseOperatorStake(from, qty)
 	assert(type(qty) == "number", "Quantity is required and must be a number")
-	-- asssert it is an integer
-	assert(utils.isInteger(qty), "Quantity must be an integer")
-	assert(qty > 0, "Quantity must be greater than 0")
+	assert(qty > 0 and utils.isInteger(qty), "Quantity must be an integer greater than 0")
 
 	local gateway = gar.getGateway(from)
 
@@ -159,7 +161,7 @@ function gar.increaseOperatorStake(from, qty)
 	gateway.operatorStake = gateway.operatorStake + qty
 	-- update the gateway
 	GatewayRegistry[from] = gateway
-	return gar.getGateway(from)
+	return gateway
 end
 
 -- Utility function to calculate withdrawal details and handle balance adjustments
@@ -228,7 +230,7 @@ function gar.decreaseOperatorStake(from, qty, currentTimestamp, msgId, instantWi
 	GatewayRegistry[from] = gateway
 
 	return {
-		gateway = gar.getGateway(from),
+		gateway = gateway,
 		penaltyRate = penaltyRate,
 		expeditedWithdrawalFee = expeditedWithdrawalFee,
 		amountWithdrawn = amountToWithdraw,
@@ -301,9 +303,9 @@ function gar.updateGatewaySettings(from, updatedSettings, updatedServices, obser
 	if observerAddress then
 		gateway.observerAddress = observerAddress
 	end
-	-- update the gateway
+	-- update the gateway on the global state
 	GatewayRegistry[from] = gateway
-	return gar.getGateway(from)
+	return gateway
 end
 
 --- Gets a gateway by address

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -350,6 +350,7 @@ function gar.delegateStake(from, target, qty, currentTimestamp)
 	-- Assuming `gateway` is a table and `fromAddress` is defined
 	local existingDelegate = gateway.delegates[from]
 	local minimumStakeForGatewayAndDelegate
+	-- if it is not an auto stake provided by the protocol, then we need to validate the stake amount meets the gateway's minDelegatedStake
 	if existingDelegate and existingDelegate.delegatedStake ~= 0 then
 		-- It already has a stake that is not zero
 		minimumStakeForGatewayAndDelegate = 1 -- Delegate must provide at least one additional IO
@@ -379,6 +380,24 @@ function gar.delegateStake(from, target, qty, currentTimestamp)
 	-- update the gateway
 	GatewayRegistry[target] = gateway
 	return gar.getGateway(target)
+end
+
+function gar.increaseExistingDelegateStake(gatewayAddress, delegateAddress, qty)
+	local gateway = gar.getGateway(gatewayAddress)
+
+	if not gateway then
+		error("Gateway not found")
+	end
+
+	local delegate = gateway.delegates[delegateAddress]
+	if not delegate then
+		error("Delegate not found")
+	end
+
+	gateway.delegates[delegateAddress].delegatedStake = delegate.delegatedStake + qty
+	gateway.totalDelegatedStake = gateway.totalDelegatedStake + qty
+	GatewayRegistry[gatewayAddress] = gateway
+	return gar.getGateway(gatewayAddress)
 end
 
 function gar.getSettings()

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -206,6 +206,9 @@ function utils.walletHasSufficientBalance(wallet, quantity)
 	return Balances[wallet] ~= nil and Balances[wallet] >= quantity
 end
 
+--- Deep copies a table
+---@param original table The table to copy
+---@return table|nil The deep copy of the table or nil if the original is nil
 function utils.deepCopy(original)
 	if not original then
 		return nil


### PR DESCRIPTION
All delegates will have their rewards restaked against the rewarded gateway, rather than going to their balance. This is default behavior and cannot be overwritten