### PR TITLE
chore: add git hash to evolve.mjs PE-6589

### DIFF
--- a/tools/evolve.mjs
+++ b/tools/evolve.mjs
@@ -1,6 +1,16 @@
 import { AOProcess, createAoSigner, ArweaveSigner } from '@ar.io/sdk/node';
 import * as constants from './constants.mjs';
 import { connect } from '@permaweb/aoconnect';
+import { execSync } from 'child_process';
+
+// Retrieve the Git hash directly in the script
+let gitHash;
+try {
+  gitHash = execSync('git rev-parse --short HEAD').toString().trim();
+} catch (error) {
+  console.error('Error retrieving Git hash:', error);
+  gitHash = 'unknown';
+}
 
 const wallet = JSON.parse(process.env.WALLET);
 const signer = createAoSigner(new ArweaveSigner(wallet));
@@ -12,7 +22,10 @@ const networkProcess = new AOProcess({
 });
 
 const { id } = await networkProcess.send({
-  tags: [{ name: 'Action', value: 'Eval' }],
+  tags: [
+    { name: 'Action', value: 'Eval' },
+    { name: 'Git-Hash', value: gitHash },
+  ],
   data: constants.BUNDLED_SOURCE_CODE,
   signer,
 });

--- a/tools/evolve.mjs
+++ b/tools/evolve.mjs
@@ -3,15 +3,6 @@ import * as constants from './constants.mjs';
 import { connect } from '@permaweb/aoconnect';
 import { execSync } from 'child_process';
 
-// Retrieve the Git hash directly in the script
-let gitHash;
-try {
-  gitHash = execSync('git rev-parse --short HEAD').toString().trim();
-} catch (error) {
-  console.error('Error retrieving Git hash:', error);
-  gitHash = 'unknown';
-}
-
 const wallet = JSON.parse(process.env.WALLET);
 const signer = createAoSigner(new ArweaveSigner(wallet));
 const networkProcess = new AOProcess({
@@ -21,11 +12,18 @@ const networkProcess = new AOProcess({
   }),
 });
 
+const tags = [{ name: 'Action', value: 'Eval' }];
+
+try {
+  // Gracefully retrieve the Git hash directly in the script
+  const gitHash = execSync('git rev-parse --short HEAD').toString().trim();
+  tags.push({ name: 'Git-Hash', value: gitHash });
+} catch (error) {
+  console.error('Error retrieving Git hash:', error);
+}
+
 const { id } = await networkProcess.send({
-  tags: [
-    { name: 'Action', value: 'Eval' },
-    { name: 'Git-Hash', value: gitHash },
-  ],
+  tags,
   data: constants.BUNDLED_SOURCE_CODE,
   signer,
 });


### PR DESCRIPTION
accidently pushed to develop, verified this during that:

<img width="1076" alt="image" src="https://github.com/user-attachments/assets/5e86496e-414b-4cfd-a594-34b7b34ba5ea">
