### PR TITLE
PE-7093: delegations handler

### DIFF
--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -2676,4 +2676,155 @@ describe("gar", function()
 			}, _G.GatewayRegistry["gateway-2"])
 		end)
 	end)
+
+	describe("getPaginatedDelegations", function()
+		local gateway1 = utils.deepCopy(testGateway)
+		local gateway2 = utils.deepCopy(testGateway)
+		gateway1.delegates = {
+			["test-user"] = {
+				delegatedStake = 1,
+				startTimestamp = 2,
+				vaults = {
+					["vault_id_1"] = {
+						balance = 1000,
+						startTimestamp = 4,
+						endTimestamp = 1000,
+					},
+				},
+			},
+			["other-address"] = {
+				delegatedStake = 2,
+				startTimestamp = 100,
+				vaults = {
+					["vault_id_2"] = {
+						balance = 2000,
+						startTimestamp = 103,
+						endTimestamp = 1001,
+					},
+				},
+			},
+		}
+		gateway2.delegates = {
+			["test-user"] = {
+				delegatedStake = 3,
+				startTimestamp = 0,
+				vaults = {
+					["vault_id_3"] = {
+						balance = 3000,
+						startTimestamp = 1,
+						endTimestamp = 1002,
+					},
+				},
+			},
+		}
+		local expectedStakeA = {
+			type = "stake",
+			gatewayAddress = stubRandomAddress,
+			balance = 3,
+			startTimestamp = 0,
+			delegationId = stubRandomAddress .. "_0",
+		}
+		local expectedStakeB = {
+			type = "vault",
+			vaultId = "vault_id_3",
+			gatewayAddress = stubRandomAddress,
+			balance = 3000,
+			startTimestamp = 1,
+			endTimestamp = 1002,
+			delegationId = stubRandomAddress .. "_1",
+		}
+		local expectedStakeC = {
+			type = "stake",
+			gatewayAddress = stubGatewayAddress,
+			balance = 1,
+			startTimestamp = 2,
+			delegationId = stubGatewayAddress .. "_2",
+		}
+		local expectedStakeD = {
+			type = "vault",
+			vaultId = "vault_id_1",
+			gatewayAddress = stubGatewayAddress,
+			balance = 1000,
+			startTimestamp = 4,
+			endTimestamp = 1000,
+			delegationId = stubGatewayAddress .. "_4",
+		}
+
+		before_each(function()
+			_G.GatewayRegistry = {
+				[stubGatewayAddress] = gateway1,
+				[stubRandomAddress] = gateway2,
+			}
+		end)
+
+		it(
+			"should return paginated delegatations of stakes and vaults sorted by startTimestamp in ascending order (oldest first)",
+			function()
+				local delegations = gar.getPaginatedDelegations("test-user", nil, 3, "startTimestamp", "asc")
+				assert.are.same({
+					limit = 3,
+					sortBy = "startTimestamp",
+					sortOrder = "asc",
+					hasMore = true,
+					nextCursor = stubGatewayAddress .. "_2",
+					totalItems = 4,
+					items = {
+						[1] = expectedStakeA,
+						[2] = expectedStakeB,
+						[3] = expectedStakeC,
+					},
+				}, delegations)
+				-- get the next page
+				local nextDelegations =
+					gar.getPaginatedDelegations("test-user", delegations.nextCursor, 3, "startTimestamp", "asc")
+				assert.are.same({
+					limit = 3,
+					sortBy = "startTimestamp",
+					sortOrder = "asc",
+					hasMore = false,
+					nextCursor = nil,
+					totalItems = 4,
+					items = {
+						[1] = expectedStakeD,
+					},
+				}, nextDelegations)
+				--
+			end
+		)
+
+		it(
+			"should return paginated delegatations of stakes and vaults sorted by balance in descending order",
+			function()
+				local delegations = gar.getPaginatedDelegations("test-user", nil, 3, "balance", "desc")
+				assert.are.same({
+					limit = 3,
+					sortBy = "balance",
+					sortOrder = "desc",
+					hasMore = true,
+					nextCursor = stubRandomAddress .. "_0",
+					totalItems = 4,
+					items = {
+						[1] = expectedStakeB,
+						[2] = expectedStakeD,
+						[3] = expectedStakeA,
+					},
+				}, delegations)
+				-- get the next page
+				local nextDelegations =
+					gar.getPaginatedDelegations("test-user", delegations.nextCursor, 3, "balance", "desc")
+				assert.are.same({
+					limit = 3,
+					sortBy = "balance",
+					sortOrder = "desc",
+					hasMore = false,
+					nextCursor = nil,
+					totalItems = 4,
+					items = {
+						[1] = expectedStakeC,
+					},
+				}, nextDelegations)
+				--
+			end
+		)
+	end)
 end)

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -1452,4 +1452,72 @@ function gar.applyFundingPlan(fundingPlan, msgId, currentTimestamp)
 	return appliedPlan
 end
 
+--- Fetch copies of all the delegations present across all gateways for the given address
+--- @param address string The address of the delegator
+--- @return table # a table, indexed by gateway address, of all the address's delegations, including nested vaults
+function gar.getDelegations(address)
+	return utils.reduce(gar.getGatewaysUnsafe(), function(acc, gatewayAddress, gateway)
+		if gateway.delegates[address] then
+			acc[gatewayAddress] = utils.deepCopy(gateway.delegates[address])
+		end
+		return acc
+	end, {})
+end
+
+---@class Delegation
+---@field type string # The type of the object. Either "stake" or "vault"
+---@field gatewayAddress string # The address of the gateway the delegation is associated with
+---@field delegateStake number|nil # The amount of stake delegated to the gateway if type is "stake"
+---@field startTimestamp number # The start timestamp of the delegation's initial stake or the vault's creation
+---@field messageId string|nil # The message ID associated with the vault's creation if type is "vault"
+---@field balance number|nil # The balance of the vault if type is "vault"
+---@field endTimestamp number|nil # The end timestamp of the vault if type is "vault"
+---@field delegationId string # The unique ID of the delegation
+
+--- Fetch a flattened array of all the delegations (stakes and vaults) present across all gateways for the given address
+--- @param address string The address of the delegator
+--- @return Delegation[] # A table of all the address's staked and vaulted delegations
+function gar.getFlattenedDelegations(address)
+	return utils.reduce(gar.getDelegations(address), function(acc, gatewayAddress, delegation)
+		table.insert(acc, {
+			type = "stake",
+			gatewayAddress = gatewayAddress,
+			balance = delegation.delegatedStake,
+			startTimestamp = delegation.startTimestamp,
+			delegationId = gatewayAddress .. "_" .. delegation.startTimestamp,
+		})
+		for vaultId, vault in pairs(delegation.vaults) do
+			table.insert(acc, {
+				type = "vault",
+				gatewayAddress = gatewayAddress,
+				startTimestamp = vault.startTimestamp,
+				vaultId = vaultId,
+				balance = vault.balance,
+				endTimestamp = vault.endTimestamp,
+				delegationId = gatewayAddress .. "_" .. vault.startTimestamp,
+			})
+		end
+		return acc
+	end, {})
+end
+
+--- Fetch a heterogenous array of all active and vaulted delegated stakes, cursored on startTimestamp
+--- @param address string The address of the delegator
+--- @param cursor number|nil The cursor startTimestamp after which to fetch more stakes (optional)
+--- @param limit number The max number of stakes to fetch
+--- @param sortBy string The field to sort by. Default is "startTimestamp"
+--- @param sortOrder string The order to sort by, either "asc" or "desc". Default is "asc"
+--- @return PaginatedTable # A table containing the paginated stakes and pagination metadata as Delegation objects
+function gar.getPaginatedDelegations(address, cursor, limit, sortBy, sortOrder)
+	local delegationsArray = gar.getFlattenedDelegations(address)
+	return utils.paginateTableWithCursor(
+		delegationsArray,
+		cursor,
+		"delegationId",
+		limit,
+		sortBy or "startTimestamp",
+		sortOrder or "asc"
+	)
+end
+
 return gar

--- a/src/main.lua
+++ b/src/main.lua
@@ -3124,6 +3124,7 @@ end)
 
 addEventingHandler("paginatedDelegations", utils.hasMatchingTag("Action", "Paginated-Delegations"), function(msg)
 	local address = utils.formatAddress(msg.Tags.Address or msg.From)
+	local page = utils.parsePaginationTags(msg)
 	local function checkAssertions()
 		assert(utils.isValidAOAddress(address), "Invalid address.")
 	end
@@ -3144,7 +3145,7 @@ addEventingHandler("paginatedDelegations", utils.hasMatchingTag("Action", "Pagin
 			Tags = { Action = "Invalid-" .. ActionMap.Delegations .. "-Notice", Error = "Pagination-Error" },
 			Data = tostring(error),
 		})
-	end, gar.getDelegations, address)
+	end, gar.getPaginatedDelegations, address, page.cursor, page.limit, page.sortBy, page.sortOrder)
 	if not shouldContinue2 then
 		return
 	end

--- a/src/main.lua
+++ b/src/main.lua
@@ -94,6 +94,7 @@ local ActionMap = {
 	AuctionPrices = "Auction-Prices",
 	AllowDelegates = "Allow-Delegates",
 	DisallowDelegates = "Disallow-Delegates",
+	Delegations = "Delegations",
 }
 
 -- Low fidelity trackers
@@ -3118,6 +3119,40 @@ addEventingHandler("disallowDelegates", utils.hasMatchingTag("Action", ActionMap
 		Target = msg.From,
 		Tags = { Action = ActionMap.DisallowDelegates .. "-Notice" },
 		Data = json.encode(result and result.removedDelegates or {}),
+	})
+end)
+
+addEventingHandler("paginatedDelegations", utils.hasMatchingTag("Action", "Paginated-Delegations"), function(msg)
+	local address = utils.formatAddress(msg.Tags.Address or msg.From)
+	local function checkAssertions()
+		assert(utils.isValidAOAddress(address), "Invalid address.")
+	end
+	local shouldContinue = eventingPcall(msg.ioEvent, function(error)
+		ao.send({
+			Target = msg.From,
+			Tags = { Action = "Invalid-" .. ActionMap.Delegations .. "-Notice", Error = "Bad-Input" },
+			Data = tostring(error),
+		})
+	end, checkAssertions)
+	if not shouldContinue then
+		return
+	end
+
+	local shouldContinue2, result = eventingPcall(msg.ioEvent, function(error)
+		ao.send({
+			Target = msg.From,
+			Tags = { Action = "Invalid-" .. ActionMap.Delegations .. "-Notice", Error = "Pagination-Error" },
+			Data = tostring(error),
+		})
+	end, gar.getDelegations, address)
+	if not shouldContinue2 then
+		return
+	end
+
+	ao.send({
+		Target = msg.From,
+		Tags = { Action = ActionMap.Delegations .. "-Notice" },
+		Data = json.encode(result),
 	})
 end)
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -178,12 +178,12 @@ end
 --- @field totalItems number The total number of items
 --- @field sortBy string|nil The field to sort by, nil if sorting by the primitive items themselves
 --- @field sortOrder string The order to sort by
---- @field nextCursor string|nil The cursor to the next page
+--- @field nextCursor string|number|nil The cursor to the next page
 --- @field hasMore boolean Whether there is a next page
 
 --- Paginate a table with a cursor
 --- @param tableArray table The table to paginate
---- @param cursor string|nil The cursor to paginate from (optional)
+--- @param cursor string|number|nil The cursor to paginate from (optional)
 --- @param cursorField string|nil The field to use as the cursor or nil for lists of primitives
 --- @param limit number The limit of items to return
 --- @param sortBy string|nil The field to sort by. Nil if sorting by the primitive items themselves.

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -1427,4 +1427,148 @@ describe('GatewayRegistry', async () => {
       // Steps: add a gateway, create the first epoch to prescribe it, submit an observation from the gateway, tick to the epoch distribution timestamp, check the rewards were distributed correctly
     });
   });
+
+  describe('Paginated-Delegations', () => {
+    async function testPaginatedDelegations({
+      sortBy,
+      sortOrder,
+      expectedDelegations,
+    }) {
+      const userAddress = 'user-address-'.padEnd(43, 'a');
+
+      // add another gateway
+      const secondGatewayAddress = 'second-gateway-'.padEnd(43, 'a');
+      const { memory: addGatewayMemory2 } = await joinNetwork({
+        address: secondGatewayAddress,
+        memory: sharedMemory,
+        timestamp: STUB_TIMESTAMP - 1,
+      });
+
+      // Stake to both gateways
+      const { memory: stakedMemory } = await delegateStake({
+        memory: addGatewayMemory2,
+        timestamp: STUB_TIMESTAMP,
+        delegatorAddress: userAddress,
+        quantity: 1_000_000_000,
+        gatewayAddress: STUB_ADDRESS,
+      });
+      const { memory: stakedMemory2 } = await delegateStake({
+        memory: stakedMemory,
+        timestamp: STUB_TIMESTAMP + 1,
+        delegatorAddress: userAddress,
+        quantity: 600_000_000,
+        gatewayAddress: secondGatewayAddress,
+      });
+
+      // Decrease stake on first gateway to create a vault
+      const decreaseQty = 400_000_001;
+      const { memory: decreaseStakeMemory } = await decreaseDelegateStake({
+        memory: stakedMemory2,
+        timestamp: STUB_TIMESTAMP + 2,
+        delegatorAddress: userAddress,
+        decreaseQty,
+        gatewayAddress: STUB_ADDRESS,
+        messageId: 'decrease-stake-message-id',
+      });
+
+      let cursor;
+      let fetchedDelegations = [];
+      while (true) {
+        const paginatedDelegations = await handle(
+          {
+            From: userAddress,
+            Owner: userAddress,
+            Tags: [
+              { name: 'Action', value: 'Paginated-Delegations' },
+              { name: 'Limit', value: '1' },
+              { name: 'Sort-By', value: sortBy },
+              { name: 'Sort-Order', value: sortOrder },
+              ...(cursor ? [{ name: 'Cursor', value: `${cursor}` }] : []),
+            ],
+          },
+          decreaseStakeMemory,
+        );
+        const { items, nextCursor, hasMore, totalItems } = JSON.parse(
+          paginatedDelegations.Messages?.[0]?.Data,
+        );
+        assert.equal(totalItems, 3);
+        assert.equal(items.length, 1);
+        assert.equal(hasMore, !!nextCursor);
+        cursor = nextCursor;
+        fetchedDelegations.push(...items);
+        if (!cursor) break;
+      }
+      assert.deepEqual(fetchedDelegations, expectedDelegations);
+    }
+
+    it('should paginate active and vaulted stakes by ascending balance correctly', async () => {
+      await testPaginatedDelegations({
+        sortBy: 'balance',
+        sortOrder: 'asc',
+        expectedDelegations: [
+          {
+            type: 'vault',
+            gatewayAddress: '2222222222222222222222222222222222222222222',
+            startTimestamp: 21600002,
+            delegationId:
+              '2222222222222222222222222222222222222222222_21600002',
+            balance: 400000001,
+            vaultId: 'decrease-stake-message-id',
+            endTimestamp: 2613600002,
+          },
+          {
+            type: 'stake',
+            gatewayAddress: '2222222222222222222222222222222222222222222',
+            delegationId:
+              '2222222222222222222222222222222222222222222_21600000',
+            balance: 599999999,
+            startTimestamp: 21600000,
+          },
+          {
+            type: 'stake',
+            gatewayAddress: 'second-gateway-aaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            delegationId:
+              'second-gateway-aaaaaaaaaaaaaaaaaaaaaaaaaaaa_21600001',
+            balance: 600000000,
+            startTimestamp: 21600001,
+          },
+        ],
+      });
+    });
+
+    it('should paginate active and vaulted stakes by descending timestamp correctly', async () => {
+      await testPaginatedDelegations({
+        sortBy: 'startTimestamp',
+        sortOrder: 'desc',
+        expectedDelegations: [
+          {
+            type: 'vault',
+            gatewayAddress: '2222222222222222222222222222222222222222222',
+            startTimestamp: 21600002,
+            delegationId:
+              '2222222222222222222222222222222222222222222_21600002',
+            balance: 400000001,
+            vaultId: 'decrease-stake-message-id',
+            endTimestamp: 2613600002,
+          },
+          {
+            type: 'stake',
+            gatewayAddress: 'second-gateway-aaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            delegationId:
+              'second-gateway-aaaaaaaaaaaaaaaaaaaaaaaaaaaa_21600001',
+            balance: 600000000,
+            startTimestamp: 21600001,
+          },
+          {
+            type: 'stake',
+            gatewayAddress: '2222222222222222222222222222222222222222222',
+            delegationId:
+              '2222222222222222222222222222222222222222222_21600000',
+            balance: 599999999,
+            startTimestamp: 21600000,
+          },
+        ],
+      });
+    });
+  });
 });

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -38,7 +38,7 @@ describe('handlers', async () => {
     const evalIndex = handlersList.indexOf('_eval');
     const defaultIndex = handlersList.indexOf('_default');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 63; // TODO: update this if more handlers are added
+    const expectedHandlerCount = 64; // TODO: update this if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
     assert.ok(pruneIndex === 2);


### PR DESCRIPTION
The handler returns a heterogenous, flattened list of active and vaulted delegations. Sorting can be done somewhat effectively by any fields that are common to both types of item. Here's an example list of items:
```
      [
          {
            type: 'vault',
            gatewayAddress: '2222222222222222222222222222222222222222222',
            startTimestamp: 21600002,
            delegationId:
              '2222222222222222222222222222222222222222222_21600002',
            balance: 400000001,
            vaultId: 'decrease-stake-message-id',
            endTimestamp: 2613600002,
          },
          {
            type: 'stake',
            gatewayAddress: '2222222222222222222222222222222222222222222',
            delegationId:
              '2222222222222222222222222222222222222222222_21600000',
            balance: 599999999,
            startTimestamp: 21600000,
          },
          {
            type: 'stake',
            gatewayAddress: 'second-gateway-aaaaaaaaaaaaaaaaaaaaaaaaaaaa',
            delegationId:
              'second-gateway-aaaaaaaaaaaaaaaaaaaaaaaaaaaa_21600001',
            balance: 600000000,
            startTimestamp: 21600001,
          },
        ]
```
The `delegationId` field was added to eliminate ambiguity of cursor values that exist for other fields. For example, timestamps might not be an effective field because a pruning operation could kick 2 gateways at which a delegate is staked, resulting in 2 withdraw vaults with the same startTimestamp and message Id.