### PR TITLE
fix(aos): update handler to be compliant with 2.0.1 token spec

### DIFF
--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -57,6 +57,16 @@ describe('handlers', async () => {
         Tags: [
           {
             name: 'Action',
+            value: 'Total-Supply',
+          },
+        ],
+      });
+
+      // for backwards compatibility, we also accept the old tag
+      const supplyResult2 = await handle({
+        Tags: [
+          {
+            name: 'Action',
             value: 'Total-Token-Supply',
           },
         ],
@@ -64,13 +74,12 @@ describe('handlers', async () => {
 
       // assert no errors
       assert.deepEqual(supplyResult.Messages?.[0]?.Error, undefined);
-
+      assert.deepEqual(supplyResult2.Messages?.[0]?.Error, undefined);
       // assert correct tag in message by finding the index of the tag in the message
       const notice = supplyResult.Messages?.[0]?.Tags?.find(
-        (tag) =>
-          tag.name === 'Action' && tag.value === 'Total-Token-Supply-Notice',
+        (tag) => tag.name === 'Action' && tag.value === 'Total-Supply-Notice',
       );
-      assert.ok(notice, 'should have a Total-Token-Supply-Notice tag');
+      assert.ok(notice, 'should have a Total-Supply-Notice tag');
 
       const supplyData = JSON.parse(supplyResult.Messages?.[0]?.Data);
 


### PR DESCRIPTION
Also removes unused pnp supply data as we immediately withdraw from balance on primary name requests instead of holding balance.