### PR TITLE
fix(io): break out token supply handlers and use function to compute

### DIFF
--- a/src/gar.lua
+++ b/src/gar.lua
@@ -334,7 +334,7 @@ end
 
 --- @param from WalletAddress
 --- @param updatedSettings UpdateGatewaySettings
---- @param updatedServices GatewayServices
+--- @param updatedServices GatewayServices|nil
 --- @param observerAddress WalletAddress
 --- @param currentTimestamp Timestamp
 --- @param msgId MessageId

--- a/src/main.lua
+++ b/src/main.lua
@@ -45,7 +45,7 @@ local ActionMap = {
 	-- reads
 	Info = "Info",
 	TotalSupply = "Total-Supply", -- for token.lua spec compatibility, gives just the total supply (circulating + locked + staked + delegated + withdraw)
-	TotalTokenSupply = "Total-Token-Supply", -- gives the total token supply, including the protocol balance, locked supply, staked supply, delegated supply, and withdraw supply
+	TotalTokenSupply = "Total-Token-Supply", -- gives the total token supply and all components (protocol balance, locked supply, staked supply, delegated supply, and withdraw supply)
 	State = "State",
 	Transfer = "Transfer",
 	Balance = "Balance",

--- a/src/main.lua
+++ b/src/main.lua
@@ -1503,7 +1503,7 @@ addEventingHandler(
 	end
 )
 
--- Reference: https://github.com/permaweb/aos/blob/main/blueprints/token.lua#L264-L280
+-- Reference: https://github.com/permaweb/aos/blob/eea71b68a4f89ac14bf6797804f97d0d39612258/blueprints/token.lua#L264-L280
 addEventingHandler("totalSupply", utils.hasMatchingTag("Action", ActionMap.TotalSupply), function(msg)
 	assert(msg.From ~= ao.id, "Cannot call Total-Supply from the same process!")
 	local totalSupplyDetails = token.computeTotalSupply()

--- a/src/token.lua
+++ b/src/token.lua
@@ -1,0 +1,99 @@
+local token = {}
+local constants = require("constants")
+local balances = require("balances")
+local gar = require("gar")
+local vaults = require("vaults")
+
+TotalSupply = TotalSupply or constants.totalTokenSupply
+LastKnownCirculatingSupply = LastKnownCirculatingSupply or 0 -- total circulating supply (e.g. balances - protocol balance)
+LastKnownLockedSupply = LastKnownLockedSupply or 0 -- total vault balance across all vaults
+LastKnownStakedSupply = LastKnownStakedSupply or 0 -- total operator stake across all gateways
+LastKnownDelegatedSupply = LastKnownDelegatedSupply or 0 -- total delegated stake across all gateways
+LastKnownWithdrawSupply = LastKnownWithdrawSupply or 0 -- total withdraw supply across all gateways (gateways and delegates)
+
+--- @return mIO # returns the last computed total supply, this is to avoid recomputing the total supply every time, and only when requested
+function token.lastKnownTotalTokenSupply()
+	return LastKnownCirculatingSupply
+		+ LastKnownLockedSupply
+		+ LastKnownStakedSupply
+		+ LastKnownDelegatedSupply
+		+ LastKnownWithdrawSupply
+		+ Balances[Protocol]
+end
+
+--- @class TotalSupplyDetails
+--- @field totalSupply number
+--- @field circulatingSupply number
+--- @field lockedSupply number
+--- @field stakedSupply number
+--- @field delegatedSupply number
+--- @field withdrawSupply number
+--- @field protocolBalance number
+
+--- Crawls the state to compute the total supply and update the last known values
+--- @return TotalSupplyDetails
+function token.computeTotalSupply()
+	-- add all the balances
+	local totalSupply = 0
+	local circulatingSupply = 0
+	local lockedSupply = 0
+	local stakedSupply = 0
+	local delegatedSupply = 0
+	local withdrawSupply = 0
+	local protocolBalance = balances.getBalance(Protocol)
+	local userBalances = balances.getBalances()
+
+	-- tally circulating supply
+	for _, balance in pairs(userBalances) do
+		circulatingSupply = circulatingSupply + balance
+	end
+	circulatingSupply = circulatingSupply - protocolBalance
+	totalSupply = totalSupply + protocolBalance + circulatingSupply
+
+	-- tally supply stashed in gateways and delegates
+	for _, gateway in pairs(gar.getGatewaysUnsafe()) do
+		totalSupply = totalSupply + gateway.operatorStake + gateway.totalDelegatedStake
+		stakedSupply = stakedSupply + gateway.operatorStake
+		delegatedSupply = delegatedSupply + gateway.totalDelegatedStake
+		for _, delegate in pairs(gateway.delegates) do
+			-- tally delegates' vaults
+			for _, vault in pairs(delegate.vaults) do
+				totalSupply = totalSupply + vault.balance
+				withdrawSupply = withdrawSupply + vault.balance
+			end
+		end
+		-- tally gateway's own vaults
+		for _, vault in pairs(gateway.vaults) do
+			totalSupply = totalSupply + vault.balance
+			withdrawSupply = withdrawSupply + vault.balance
+		end
+	end
+
+	-- user vaults
+	local userVaults = vaults.getVaults()
+	for _, vaultsForAddress in pairs(userVaults) do
+		-- they may have several vaults iterate through them
+		for _, vault in pairs(vaultsForAddress) do
+			totalSupply = totalSupply + vault.balance
+			lockedSupply = lockedSupply + vault.balance
+		end
+	end
+
+	LastKnownCirculatingSupply = circulatingSupply
+	LastKnownLockedSupply = lockedSupply
+	LastKnownStakedSupply = stakedSupply
+	LastKnownDelegatedSupply = delegatedSupply
+	LastKnownWithdrawSupply = withdrawSupply
+	TotalSupply = totalSupply
+	return {
+		totalSupply = totalSupply,
+		circulatingSupply = circulatingSupply,
+		lockedSupply = lockedSupply,
+		stakedSupply = stakedSupply,
+		delegatedSupply = delegatedSupply,
+		withdrawSupply = withdrawSupply,
+		protocolBalance = protocolBalance,
+	}
+end
+
+return token


### PR DESCRIPTION
The token spec expects just the raw value for total supply, so separating it to a separate handler. Additionally, moves the computation to a function so we can add unit tests.