### PR TITLE
PE-7147: Prune Epochs Only When Necessary

### DIFF
--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -880,7 +880,9 @@ describe("epochs", function()
 
 	-- prune epochs
 	describe("pruneEpochs", function()
-		it("should prune epochs older than 14 days", function()
+		local startingEpochs
+		before_each(function()
+			_G.Epochs = {}
 			-- add 20 epochs
 			for i = 0, 20 do
 				_G.Epochs[i] = {
@@ -890,6 +892,10 @@ describe("epochs", function()
 					distributionTimestamp = 1704092400115,
 				}
 			end
+			startingEpochs = utils.deepCopy(_G.Epochs)
+		end)
+
+		it("should prune epochs older than 14 days", function()
 			local currentTimestamp = epochs.getSettings().epochZeroStartTimestamp
 				+ epochs.getSettings().durationMs * 20
 				+ 1
@@ -913,6 +919,18 @@ describe("epochs", function()
 				[19] = _G.Epochs[19],
 				[20] = _G.Epochs[20],
 			}, _G.Epochs)
+		end)
+
+		it("should skip pruning when unnecessary", function()
+			local currentTimestamp = epochs.getSettings().epochZeroStartTimestamp
+				+ epochs.getSettings().durationMs * 20
+				+ 1
+			_G.NextEpochsPruneTimestamp = currentTimestamp + 1
+			-- prune epochs
+			local result = epochs.pruneEpochs(currentTimestamp)
+			assert.are.same({}, result)
+			assert.are.same(startingEpochs, _G.Epochs)
+			assert.are.equal(currentTimestamp + 1, _G.NextEpochsPruneTimestamp)
 		end)
 	end)
 end)

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -46,7 +46,7 @@ describe("epochs", function()
 			durationMs = 100,
 			distributionDelayMs = 15,
 			rewardPercentage = 0.0025, -- 0.25%
-			pruneEpochsCount = 14,
+			maxCachedEpochsCount = 14,
 		}
 	end)
 

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -46,7 +46,7 @@ describe("epochs", function()
 			durationMs = 100,
 			distributionDelayMs = 15,
 			rewardPercentage = 0.0025, -- 0.25%
-			maxCachedEpochsCount = 14,
+			pruneEpochsCount = 14,
 		}
 	end)
 

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -17,7 +17,7 @@ local epochs = {}
 --- @field distributions Distribution The distributions of the epoch
 
 --- @class EpochSettings
---- @field maxCachedEpochsCount number The number of epochs to prune
+--- @field pruneEpochsCount number The number of epochs to prune
 --- @field prescribedNameCount number The number of prescribed names
 --- @field rewardPercentage number The reward percentage
 --- @field maxObservers number The maximum number of observers
@@ -61,7 +61,7 @@ local epochs = {}
 Epochs = Epochs or {}
 EpochSettings = EpochSettings
 	or {
-		maxCachedEpochsCount = 14, -- prune epochs older than 14 days
+		pruneEpochsCount = 14, -- prune epochs older than 14 days
 		prescribedNameCount = 2,
 		rewardPercentage = 0.0005, -- 0.05%
 		maxObservers = 50,
@@ -747,7 +747,7 @@ function epochs.pruneEpochs(timestamp)
 	--- Reset the next pruning timestamp
 	NextEpochsPruneTimestamp = nil
 	local currentEpochIndex = epochs.getEpochIndexForTimestamp(timestamp)
-	local cutoffEpochIndex = currentEpochIndex - epochs.getSettings().maxCachedEpochsCount
+	local cutoffEpochIndex = currentEpochIndex - epochs.getSettings().pruneEpochsCount
 	local unsafeEpochs = epochs.getEpochsUnsafe()
 	local nextEpochIndex = next(unsafeEpochs)
 	while nextEpochIndex do

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -70,6 +70,9 @@ EpochSettings = EpochSettings
 		distributionDelayMs = 60 * 1000 * 40, -- 40 minutes (~ 20 arweave blocks)
 	}
 
+--- @type Timestamp|nil
+NextEpochsPruneTimestamp = NextEpochsPruneTimestamp or 0
+
 --- Gets a deep copy of all the epochs
 --- @return table<number, Epoch> # A deep copy of the epochs indexed by their epoch index
 function epochs.getEpochs()
@@ -400,6 +403,10 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 			gar.updateGatewayWeights(weightedGateway)
 		end
 	end
+
+	-- Force schedule a pruning JIC
+	NextEpochsPruneTimestamp = NextEpochsPruneTimestamp or 0
+
 	return epoch
 end
 
@@ -732,6 +739,13 @@ end
 --- @return Epoch[] # The pruned epochs
 function epochs.pruneEpochs(timestamp)
 	local prunedEpochIndexes = {}
+	if not NextEpochsPruneTimestamp or timestamp < NextEpochsPruneTimestamp then
+		-- No known pruning work to do
+		return prunedEpochIndexes
+	end
+
+	--- Reset the next pruning timestamp
+	NextEpochsPruneTimestamp = nil
 	local currentEpochIndex = epochs.getEpochIndexForTimestamp(timestamp)
 	local cutoffEpochIndex = currentEpochIndex - epochs.getSettings().maxCachedEpochsCount
 	local unsafeEpochs = epochs.getEpochsUnsafe()
@@ -741,6 +755,9 @@ function epochs.pruneEpochs(timestamp)
 			table.insert(prunedEpochIndexes, nextEpochIndex)
 			-- Safe to assign to nil during next() iteration
 			Epochs[nextEpochIndex] = nil
+		else
+			local _, endTimestamp = epochs.getEpochTimestampsForIndex(nextEpochIndex)
+			NextEpochsPruneTimestamp = math.min(NextEpochsPruneTimestamp or endTimestamp, endTimestamp)
 		end
 		nextEpochIndex = next(unsafeEpochs, nextEpochIndex)
 	end


### PR DESCRIPTION
This one is a little different than the others because there's a very structured way in which the epochs are created and pruned. There's no need to reset the next prune timestamp after user actions here.

Note: I modified the deepCopy behavior to:
- do a very fast, basic deep copy if no exclusions are present
- if exclusions are present, activate the reindexing feature for numeric Arrays (not dictionaries)