### PR TITLE
fix(primary): fix primary name request creation, replacing name for existing owner

### DIFF
--- a/spec/primary_names_spec.lua
+++ b/spec/primary_names_spec.lua
@@ -70,6 +70,30 @@ describe("Primary Names", function()
 			assert.match("Primary name is already owned", err)
 		end)
 
+		it("should fail if the caller already has a primary name request for the same name", function()
+			_G.PrimaryNames.requests = {
+				["user-requesting-primary-name"] = { name = "test", startTimestamp = 1234567890 },
+			}
+			local status, err = pcall(
+				primaryNames.createPrimaryNameRequest,
+				"test",
+				"user-requesting-primary-name",
+				1234567890,
+				"test-msg-id"
+			)
+			assert.is_false(status)
+			assert.match(
+				"Primary name request for '"
+					.. "user-requesting-primary-name"
+					.. "' for '"
+					.. "test"
+					.. "' already exists",
+				err,
+				nil,
+				true
+			)
+		end)
+
 		it(
 			"should create a primary name request and transfer the cost from the initiator to the protocol balance",
 			function()
@@ -351,6 +375,11 @@ describe("Primary Names", function()
 				{ name = "undername_test", owner = "primary-name-owner2" },
 				{ name = "undername2_test", owner = "primary-name-owner3" },
 			}, removedPrimaryNamesAndOwners)
+			assert.are.same({
+				owners = {},
+				names = {},
+				requests = {},
+			}, _G.PrimaryNames)
 		end)
 	end)
 

--- a/spec/primary_names_spec.lua
+++ b/spec/primary_names_spec.lua
@@ -199,6 +199,43 @@ describe("Primary Names", function()
 				}, _G.PrimaryNames.names)
 			end
 		)
+
+		it("should remove the existing primary name if the recipient already has one and set the new one", function()
+			_G.NameRegistry.records = {
+				["test"] = {
+					processId = "owning-process-id",
+				},
+			}
+			_G.PrimaryNames = {
+				owners = {
+					["owner"] = { name = "test", startTimestamp = 1234567890 },
+				},
+				names = {
+					["test"] = "owner",
+				},
+				requests = {
+					["owner"] = {
+						name = "new_test",
+						startTimestamp = 1234567890,
+						endTimestamp = 1234567890 + 30 * 24 * 60 * 60 * 1000,
+					},
+				},
+			}
+			primaryNames.approvePrimaryNameRequest("owner", "new_test", "owning-process-id", 1234567890)
+			assert.are.same({
+				name = "new_test",
+				startTimestamp = 1234567890,
+			}, _G.PrimaryNames.owners["owner"])
+			assert.are.same(nil, _G.PrimaryNames.names["test"]) -- old name should be removed
+			assert.are.same({}, _G.PrimaryNames.requests) -- request should be removed
+			-- new primary name should be set
+			assert.are.same({
+				["owner"] = { name = "new_test", startTimestamp = 1234567890 },
+			}, _G.PrimaryNames.owners)
+			assert.are.same({
+				["new_test"] = "owner",
+			}, _G.PrimaryNames.names)
+		end)
 	end)
 
 	describe("getAddressForPrimaryName", function()

--- a/spec/primary_names_spec.lua
+++ b/spec/primary_names_spec.lua
@@ -83,11 +83,7 @@ describe("Primary Names", function()
 			)
 			assert.is_false(status)
 			assert.match(
-				"Primary name request for '"
-					.. "user-requesting-primary-name"
-					.. "' for '"
-					.. "test"
-					.. "' already exists",
+				[[Primary name request by 'user-requesting-primary-name' for 'test' already exists]],
 				err,
 				nil,
 				true

--- a/src/primary_names.lua
+++ b/src/primary_names.lua
@@ -48,7 +48,7 @@ local function baseNameForName(name)
 end
 
 --- Creates a transient request for a primary name. This is done by a user and must be approved by the name owner of the base name.
---- @param name string -- the name being requested, this could be an undername provided by the ant
+--- @param name string -- the name being requested, this could be an undername and should always be lower case
 --- @param initiator WalletAddress -- the address that is creating the primary name request, e.g. the ANT process id
 --- @param timestamp number -- the timestamp of the request
 --- @param msgId string -- the message id of the request
@@ -56,6 +56,7 @@ end
 --- @return CreatePrimaryNameResult # the request created, or the primary name with owner data if the request is approved
 function primaryNames.createPrimaryNameRequest(name, initiator, timestamp, msgId, fundFrom)
 	fundFrom = fundFrom or "balance"
+	name = string.lower(name)
 	local baseName = baseNameForName(name)
 
 	--- check the primary name request for the initiator does not already exist for the same name
@@ -63,7 +64,7 @@ function primaryNames.createPrimaryNameRequest(name, initiator, timestamp, msgId
 	local existingRequest = primaryNames.getPrimaryNameRequest(initiator)
 	assert(
 		not existingRequest or existingRequest.name ~= name,
-		"Primary name request for '" .. initiator .. "' for '" .. name .. "' already exists"
+		"Primary name request by '" .. initiator .. "' for '" .. name .. "' already exists"
 	)
 
 	--- check the primary name is not already owned

--- a/src/primary_names.lua
+++ b/src/primary_names.lua
@@ -165,6 +165,11 @@ end
 --- @param startTimestamp number
 --- @return PrimaryNameWithOwner # the primary name with owner data
 function primaryNames.setPrimaryNameFromRequest(recipient, request, startTimestamp)
+	--- if the owner has an existing primary name, make sure we remove it from the maps before setting the new one
+	local existingPrimaryName = primaryNames.getPrimaryNameDataWithOwnerFromAddress(recipient)
+	if existingPrimaryName then
+		primaryNames.removePrimaryName(existingPrimaryName.name, recipient)
+	end
 	PrimaryNames.names[request.name] = recipient
 	PrimaryNames.owners[recipient] = {
 		name = request.name,
@@ -212,7 +217,9 @@ function primaryNames.removePrimaryName(name, from)
 
 	PrimaryNames.names[name] = nil
 	PrimaryNames.owners[primaryName.owner] = nil
-	PrimaryNames.requests[primaryName.owner] = nil -- should never happen, but cleanup anyway
+	if PrimaryNames.requests[primaryName.owner] and PrimaryNames.requests[primaryName.owner].name == name then
+		PrimaryNames.requests[primaryName.owner] = nil
+	end
 	return {
 		name = name,
 		owner = primaryName.owner,

--- a/src/primary_names.lua
+++ b/src/primary_names.lua
@@ -58,9 +58,13 @@ function primaryNames.createPrimaryNameRequest(name, initiator, timestamp, msgId
 	fundFrom = fundFrom or "balance"
 	local baseName = baseNameForName(name)
 
-	--- existing request for primary name from wallet?
-	local existingRequest = primaryNames.getPrimaryNameRequest(name)
-	assert(not existingRequest, "Primary name request for '" .. name .. "' already exists") -- TODO: should we error here or just let them create a new request and pay the fee again?
+	--- check the primary name request for the initiator does not already exist for the same name
+	--- this allows the caller to create a new request and pay the fee again, so long as it is for a different name
+	local existingRequest = primaryNames.getPrimaryNameRequest(initiator)
+	assert(
+		not existingRequest or existingRequest.name ~= name,
+		"Primary name request for '" .. initiator .. "' for '" .. name .. "' already exists"
+	)
 
 	--- check the primary name is not already owned
 	local primaryNameOwner = primaryNames.getAddressForPrimaryName(name)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -443,7 +443,7 @@ end
 
 --- Splits a string by a delimiter
 --- @param input string The string to split
---- @param delimiter string The delimiter to split by
+--- @param delimiter string|nil The delimiter to split by
 --- @return table The split string
 function utils.splitString(input, delimiter)
 	delimiter = delimiter or ","


### PR DESCRIPTION
Allows a user to replace an existing primary name request with a new one, so long as it is a different name