### PR TITLE
Existing memory invariance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ luacov-html
 dist
 luacov.stats.out
 coverage
+tools/fixtures/memory/*

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "monitor:devnet": "IO_PROCESS_ID=GaQrvEMKBpkjofgnBi_B3IgIDmY_XYelVLB6GcRGrHc node --test tests/monitor/monitor.test.mjs",
     "monitor:testnet": "IO_PROCESS_ID=agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA node --test tests/monitor/monitor.test.mjs",
     "evolve": "yarn build && node tools/evolve.mjs",
+    "update-memory-fixtures": "yarn update-testnet-memory && yarn update-devnet-memory",
+    "update-testnet-memory": "IO_NETWORK=\"testnet\" node tools/update-memory.mjs",
+    "update-devnet-memory": "IO_NETWORK=\"devnet\" node tools/update-memory.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -19,7 +19,7 @@ import {
   delegateStake,
   decreaseOperatorStake,
 } from './helpers.mjs';
-import { describe, it, before } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import {
   STUB_TIMESTAMP,
@@ -29,6 +29,7 @@ import {
   INITIAL_OPERATOR_STAKE,
   INITIAL_DELEGATE_STAKE,
 } from '../tools/constants.mjs';
+import { assertNoInvariants } from './invariants.mjs';
 
 const delegatorAddress = 'delegator-address-'.padEnd(43, 'x');
 
@@ -40,13 +41,20 @@ describe('GatewayRegistry', async () => {
 
   let sharedMemory = startMemory; // memory we'll use across unique tests;
 
-  before(async () => {
+  beforeEach(async () => {
     const { memory: joinNetworkMemory } = await joinNetwork({
       address: STUB_ADDRESS,
-      memory: sharedMemory,
+      memory: startMemory,
     });
     // NOTE: all tests will start with this gateway joined to the network - use `sharedMemory` for the first interaction for each test to avoid having to join the network again
     sharedMemory = joinNetworkMemory;
+  });
+
+  afterEach(async () => {
+    await assertNoInvariants({
+      timestamp: STUB_TIMESTAMP,
+      memory: sharedMemory,
+    });
   });
 
   describe('Join-Network', () => {
@@ -210,7 +218,7 @@ describe('GatewayRegistry', async () => {
 
     it('should allow joining of the network with an allow list', async () => {
       const otherGatewayAddress = ''.padEnd(43, '3');
-      const updatedMemory = await allowlistJoinTest({
+      sharedMemory = await allowlistJoinTest({
         gatewayAddress: otherGatewayAddress,
         tags: [
           { name: 'Allow-Delegated-Staking', value: 'allowlist' },
@@ -229,7 +237,7 @@ describe('GatewayRegistry', async () => {
       });
 
       const delegateItems = await getDelegatesItems({
-        memory: updatedMemory,
+        memory: sharedMemory,
         gatewayAddress: otherGatewayAddress,
       });
       assert.deepStrictEqual(
@@ -244,7 +252,7 @@ describe('GatewayRegistry', async () => {
       );
 
       const { result: getAllowedDelegatesResult } = await getAllowedDelegates({
-        memory: updatedMemory,
+        memory: sharedMemory,
         from: STUB_ADDRESS,
         timestamp: STUB_TIMESTAMP,
         gatewayAddress: otherGatewayAddress,
@@ -342,6 +350,8 @@ describe('GatewayRegistry', async () => {
           },
         ],
       );
+
+      sharedMemory = leaveNetworkMemory;
     });
   });
 
@@ -444,7 +454,7 @@ describe('GatewayRegistry', async () => {
     }
 
     it('should allow updating the gateway settings', async () => {
-      await updateGatewaySettingsTest({
+      sharedMemory = await updateGatewaySettingsTest({
         settingsTags: [
           { name: 'Label', value: 'new-label' },
           { name: 'Note', value: 'new-note' },
@@ -494,7 +504,7 @@ describe('GatewayRegistry', async () => {
         expectedAllowedDelegates: [STUB_ADDRESS_9], // probs empty
       });
 
-      await updateGatewaySettingsTest({
+      sharedMemory = await updateGatewaySettingsTest({
         settingsTags: [
           { name: 'Allow-Delegated-Staking', value: 'false' },
           { name: 'Allowed-Delegates', value: STUB_ADDRESS_9 },
@@ -573,7 +583,7 @@ describe('GatewayRegistry', async () => {
         JSON.parse(delegationsResult.Messages[0].Data).items,
       );
 
-      await updateGatewaySettingsTest({
+      sharedMemory = await updateGatewaySettingsTest({
         inputMemory: updatedMemory,
         settingsTags: [{ name: 'Allow-Delegated-Staking', value: 'false' }],
         expectedUpdatedGatewayProps: {
@@ -640,6 +650,7 @@ describe('GatewayRegistry', async () => {
           sortOrder: 'desc',
         },
       );
+      sharedMemory = updatedMemory;
     });
   });
 
@@ -666,6 +677,7 @@ describe('GatewayRegistry', async () => {
         ...gatewayBefore,
         operatorStake: INITIAL_OPERATOR_STAKE + increaseQty, // matches the initial operator stake from the test setup plus the increase
       });
+      sharedMemory = increaseStakeMemory;
     });
   });
 
@@ -722,6 +734,7 @@ describe('GatewayRegistry', async () => {
           },
         ],
       );
+      sharedMemory = decreaseStakeMemory;
     });
 
     it('should not allow decreasing the operator stake if below the minimum withdrawal', async () => {
@@ -752,6 +765,7 @@ describe('GatewayRegistry', async () => {
         ),
         'Error tag should be present',
       );
+      sharedMemory = decreaseOperatorStakeResult.Memory;
     });
 
     it('should allow decreasing the operator stake instantly, for a fee', async () => {
@@ -832,6 +846,7 @@ describe('GatewayRegistry', async () => {
         balancesBefore[STUB_ADDRESS] + amountWithdrawn;
       assert.equal(balancesAfter[PROCESS_ID], expectedProtocolBalance);
       assert.equal(balancesAfter[STUB_ADDRESS], expectedOperatorBalance);
+      sharedMemory = decreaseInstantMemory;
     });
   });
 
@@ -874,6 +889,7 @@ describe('GatewayRegistry', async () => {
         ],
         delegateItems,
       );
+      sharedMemory = delegatedStakeMemory;
     });
   });
 
@@ -949,6 +965,7 @@ describe('GatewayRegistry', async () => {
           type: 'stake',
         },
       ]);
+      sharedMemory = decreaseStakeMemory;
     });
 
     it('should fail to withdraw a delegated stake if below the minimum withdrawal limitation', async () => {
@@ -995,6 +1012,7 @@ describe('GatewayRegistry', async () => {
         memory: decreaseStakeMemory,
       });
       assert.deepStrictEqual(gatewayAfter, gatewayBefore);
+      sharedMemory = decreaseStakeMemory;
     });
   });
 
@@ -1039,6 +1057,7 @@ describe('GatewayRegistry', async () => {
       });
       // no changes to the gateway after a withdrawal is cancelled
       assert.deepStrictEqual(gatewayAfter, gatewayBefore);
+      sharedMemory = cancelWithdrawalMemory;
     });
     it('should allow cancelling an operator withdrawal', async () => {
       const decreaseStakeTimestamp = STUB_TIMESTAMP + 1000 * 60 * 15; // 15 minutes after stubbedTimestamp
@@ -1084,6 +1103,7 @@ describe('GatewayRegistry', async () => {
         ...gatewayBefore,
         operatorStake: INITIAL_OPERATOR_STAKE + decreaseQty, // the decrease was cancelled and returned to the operator
       });
+      sharedMemory = cancelWithdrawalMemory;
     });
   });
 
@@ -1156,6 +1176,8 @@ describe('GatewayRegistry', async () => {
         balancesAfter[PROCESS_ID],
         balancesBefore[PROCESS_ID] + penaltyAmount,
       ); // original stake + penalty
+
+      sharedMemory = instantWithdrawalMemory;
     });
   });
 
@@ -1197,6 +1219,7 @@ describe('GatewayRegistry', async () => {
         fetchedGateways.map((g) => g.gatewayAddress),
         [STUB_ADDRESS, secondGatewayAddress],
       );
+      sharedMemory = addGatewayMemory2;
     });
   });
 
@@ -1278,6 +1301,7 @@ describe('GatewayRegistry', async () => {
         if (!cursor) break;
       }
       assert.deepStrictEqual(fetchedDelegations, expectedDelegations);
+      sharedMemory = decreaseStakeMemory;
     }
 
     it('should paginate active and vaulted stakes by ascending balance correctly', async () => {
@@ -1508,6 +1532,7 @@ describe('GatewayRegistry', async () => {
           redelegationFeeRate: 0,
         },
       );
+      sharedMemory = redelegateStakeMemory;
     });
 
     it("should allow re-delegating stake with a vault and the vault's balance", async () => {
@@ -1608,6 +1633,7 @@ describe('GatewayRegistry', async () => {
         }),
         [],
       );
+      sharedMemory = redelegateStakeMemory;
     });
   });
 });

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -9,6 +9,7 @@ import {
   STUB_TIMESTAMP,
   STUB_MESSAGE_ID,
   validGatewayTags,
+  TESTNET_MEMORY,
 } from '../tools/constants.mjs';
 
 const initialOperatorStake = 100_000_000_000;
@@ -17,7 +18,7 @@ export const basePermabuyPrice = 2_500_000_000;
 export const baseLeasePrice = 600_000_000;
 
 const { handle: originalHandle, memory } = await createAosLoader();
-export const startMemory = memory;
+export const startMemory = TESTNET_MEMORY;
 
 export async function handle(options = {}, mem = startMemory) {
   return originalHandle(

--- a/tests/invariants.mjs
+++ b/tests/invariants.mjs
@@ -1,20 +1,63 @@
 import assert from 'node:assert';
-import { getBalances } from './helpers.mjs';
+import { getBalances, getVaults } from './helpers.mjs';
+
+function assertValidBalance(balance) {
+  assert(
+    balance >= 0 && balance <= 1_000_000_000_000_000,
+    `Invariant violated: balance ${balance} is invalid`,
+  );
+}
+
+function assertValidAddress(address) {
+  assert(address.length > 0, `Invariant violated: address ${address} is empty`);
+}
+
+function assertValidTimestampsAtTimestamp({
+  startTimestamp,
+  endTimestamp,
+  timestamp,
+}) {
+  assert(
+    startTimestamp <= timestamp,
+    `Invariant violated: startTimestamp ${startTimestamp} is in the future`,
+  );
+  assert(
+    endTimestamp === null || endTimestamp >= startTimestamp,
+    `Invariant violated: endTimestamp of ${endTimestamp} for vault ${address}`,
+  );
+}
 
 export async function assertNoInvariants({ timestamp, memory }) {
+  await assertNoBalanceInvariants({ timestamp, memory });
+  await assertNoBalanceVaultInvariants({ timestamp, memory });
+}
+
+async function assertNoBalanceInvariants({ timestamp, memory }) {
   // Assert all balances are >= 0 and all belong to valid addresses
   const balances = await getBalances({
     memory,
     timestamp,
   });
   for (const [address, balance] of Object.entries(balances)) {
-    assert(
-      balance >= 0 && balance <= 1_000_000_000_000_000,
-      `Invariant violated: balance of ${balance} for address ${address}`,
-    );
-    assert(
-      address.length > 0,
-      `Invariant violated: address ${address} is empty`,
-    );
+    assertValidBalance(balance);
+    assertValidAddress(address);
+  }
+}
+
+async function assertNoBalanceVaultInvariants({ timestamp, memory }) {
+  const { result } = await getVaults({
+    memory,
+    limit: 1_000_000, // egregiously large limit to make sure we get them all
+  });
+
+  for (const vault of JSON.parse(result.Messages?.[0]?.Data).items) {
+    const { address, balance, startTimestamp, endTimestamp } = vault;
+    assertValidBalance(balance);
+    assertValidAddress(address);
+    assertValidTimestampsAtTimestamp({
+      startTimestamp,
+      endTimestamp,
+      timestamp,
+    });
   }
 }

--- a/tests/invariants.mjs
+++ b/tests/invariants.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import { getBalances } from './helpers.mjs';
+
+export async function assertNoInvariants({ timestamp, memory }) {
+  // Assert all balances are >= 0 and all belong to valid addresses
+  const balances = await getBalances({
+    memory,
+    timestamp,
+  });
+  for (const [address, balance] of Object.entries(balances)) {
+    assert(
+      balance >= 0 && balance <= 1_000_000_000_000_000,
+      `Invariant violated: balance of ${balance} for address ${address}`,
+    );
+    assert(
+      address.length > 0,
+      `Invariant violated: address ${address} is empty`,
+    );
+  }
+}

--- a/tests/invariants.mjs
+++ b/tests/invariants.mjs
@@ -3,7 +3,7 @@ import { getBalances, getVaults } from './helpers.mjs';
 
 function assertValidBalance(balance) {
   assert(
-    balance >= 0 && balance <= 1_000_000_000_000_000,
+    balance > 0 && balance <= 1_000_000_000_000_000,
     `Invariant violated: balance ${balance} is invalid`,
   );
 }
@@ -22,7 +22,7 @@ function assertValidTimestampsAtTimestamp({
     `Invariant violated: startTimestamp ${startTimestamp} is in the future`,
   );
   assert(
-    endTimestamp === null || endTimestamp >= startTimestamp,
+    endTimestamp === null || endTimestamp > startTimestamp,
     `Invariant violated: endTimestamp of ${endTimestamp} for vault ${address}`,
   );
 }

--- a/tools/constants.mjs
+++ b/tools/constants.mjs
@@ -45,6 +45,14 @@ export const AOS_WASM = fs.readFileSync(
   ),
 );
 
+export const TESTNET_MEMORY = fs.readFileSync(
+  path.join(__dirname, 'fixtures/memory/testnet'),
+);
+
+export const DEVNET_MEMORY = fs.readFileSync(
+  path.join(__dirname, 'fixtures/memory/devnet'),
+);
+
 export const BUNDLED_SOURCE_CODE = fs.readFileSync(
   path.join(__dirname, '../dist/aos-bundled.lua'),
   'utf-8',

--- a/tools/update-memory.mjs
+++ b/tools/update-memory.mjs
@@ -1,0 +1,29 @@
+import { IO_DEVNET_PROCESS_ID, IO_TESTNET_PROCESS_ID } from '@ar.io/sdk';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream';
+import { promisify } from 'node:util';
+
+const __dirname = new URL('.', import.meta.url).pathname;
+async function main() {
+  try {
+    const network = process.env.IO_NETWORK ?? 'testnet';
+    console.log(`=== Retrieving ${network} process memory === \n\n`);
+    const ioProcessId =
+      process.env.IO_NETWORK === 'devnet'
+        ? IO_DEVNET_PROCESS_ID
+        : IO_TESTNET_PROCESS_ID;
+
+    const fetchStream = await fetch(
+      `https://cu.ardrive.io/state/${ioProcessId}`,
+    );
+    const memPath = path.join(__dirname, 'fixtures', 'memory', `${network}`);
+    const writeStream = fs.createWriteStream(memPath, { recursive: true });
+    await promisify(pipeline)(fetchStream.body, writeStream);
+    console.log(`Wrote memory to ${memPath} \n\n`);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+main();


### PR DESCRIPTION
To add the current memory from the cu for both testnet and devnet, you can run `yarn update-memory-fixtures` - these are not included by default because they are quite large (300mb+).

This PR is setup to run with testnet memory - the current WASM binary used in the tests matches this memory and works.

If you attempt to run with devnet it will not work - this is likely because one memory is from a wasm64 module (testnet) and devnet is a wasm32 module.

Further testing would be required to identify if this is the issue, but also just as likely that simply being different modules make the memory incompatible (not just because they are different build types)

Further work:

If it is desired to have invariance testing with existing memory on both, simply add a network ENV var and conditionaly read the target AOS_WASM and existing memory fixtures.