### PR TITLE
fix(main): add global handler to sanitize and validate inputs, enforce `LastKnownMessageTimestamp`

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -349,43 +349,6 @@ local function assertAndSanitizeInputs(msg)
 	msg.Tags = utils.validateAndSanitizeInputs(msg.Tags)
 	msg.From = utils.formatAddress(msg.From)
 	msg.Timestamp = msg.Timestamp and tonumber(msg.Timestamp) or tonumber(msg.Tags.Timestamp) or nil
-
-	local knownAddressTags = {
-		"Recipient",
-		"Initiator",
-		"Target",
-		"Source",
-		"Address",
-		"Vault-Id",
-		"Process-Id",
-		"Observer-Address",
-	}
-
-	for _, tagName in ipairs(knownAddressTags) do
-		-- Format all incoming addresses
-		msg.Tags[tagName] = msg.Tags[tagName] and utils.formatAddress(msg.Tags[tagName]) or nil
-	end
-
-	local knownNumberTags = {
-		"Quantity",
-		"Lock-Length",
-		"Operator-Stake",
-		"Delegated-Stake",
-		"Withdraw-Stake",
-		"Timestamp",
-		"Years",
-		"Min-Delegated-Stake",
-		"Port",
-		"Extend-Length",
-		"Delegate-Reward-Share-Ratio",
-		"Epoch-Index",
-		"Price-Interval-Ms",
-		"Block-Height",
-	}
-	for _, tagName in ipairs(knownNumberTags) do
-		-- Format all incoming numbers
-		msg.Tags[tagName] = msg.Tags[tagName] and tonumber(msg.Tags[tagName]) or nil
-	end
 end
 
 local function updateLastKnownMessage(msg)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -573,6 +573,7 @@ end
 --- @return table sanitizedTable - the sanitized table
 function utils.validateAndSanitizeInputs(table)
 	assert(type(table) == "table", "Table must be a table")
+	local sanitizedTable = {}
 	for key, value in pairs(table) do
 		assert(type(key) == "string", "Key must be a string")
 		assert(
@@ -591,8 +592,46 @@ function utils.validateAndSanitizeInputs(table)
 		if type(value) == "number" then
 			assert(utils.isInteger(value), "Number must be an integer")
 		end
+		sanitizedTable[key] = value
 	end
-	return table
+
+	local knownAddressTags = {
+		"Recipient",
+		"Initiator",
+		"Target",
+		"Source",
+		"Address",
+		"Vault-Id",
+		"Process-Id",
+		"Observer-Address",
+	}
+
+	for _, tagName in ipairs(knownAddressTags) do
+		-- Format all incoming addresses
+		sanitizedTable[tagName] = sanitizedTable[tagName] and utils.formatAddress(sanitizedTable[tagName]) or nil
+	end
+
+	local knownNumberTags = {
+		"Quantity",
+		"Lock-Length",
+		"Operator-Stake",
+		"Delegated-Stake",
+		"Withdraw-Stake",
+		"Timestamp",
+		"Years",
+		"Min-Delegated-Stake",
+		"Port",
+		"Extend-Length",
+		"Delegate-Reward-Share-Ratio",
+		"Epoch-Index",
+		"Price-Interval-Ms",
+		"Block-Height",
+	}
+	for _, tagName in ipairs(knownNumberTags) do
+		-- Format all incoming numbers
+		sanitizedTable[tagName] = sanitizedTable[tagName] and tonumber(sanitizedTable[tagName]) or nil
+	end
+	return sanitizedTable
 end
 
 return utils

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -568,4 +568,31 @@ function utils.filterDictionary(tbl, predicate)
 	return filtered
 end
 
+--- Sanitizes inputs to ensure they are valid strings
+--- @param table table The table to sanitize
+--- @return table sanitizedTable - the sanitized table
+function utils.validateAndSanitizeInputs(table)
+	assert(type(table) == "table", "Table must be a table")
+	for key, value in pairs(table) do
+		assert(type(key) == "string", "Key must be a string")
+		assert(
+			type(value) == "string" or type(value) == "number" or type(value) == "boolean",
+			"Value must be a string, integer, or boolean"
+		)
+		if type(value) == "string" then
+			assert(#key > 0, "Key cannot be empty")
+			assert(#value > 0, "Value cannot be empty")
+			assert(not string.match(key, "^%s+$"), "Key cannot be only whitespace")
+			assert(not string.match(value, "^%s+$"), "Value cannot be only whitespace")
+		end
+		if type(value) == "boolean" then
+			assert(value == true or value == false, "Boolean value must be true or false")
+		end
+		if type(value) == "number" then
+			assert(utils.isInteger(value), "Number must be an integer")
+		end
+	end
+	return table
+end
+
 return utils

--- a/tests/arns.test.mjs
+++ b/tests/arns.test.mjs
@@ -612,7 +612,6 @@ describe('ArNS', async () => {
             { name: 'Process-Id', value: ''.padEnd(43, 'a') },
             { name: 'Fund-From', value: 'any' },
           ],
-          Timestamp: STUB_TIMESTAMP + 1,
         },
         memory,
       );
@@ -626,7 +625,6 @@ describe('ArNS', async () => {
             { name: 'Action', value: 'Record' },
             { name: 'Name', value: 'test-name' },
           ],
-          Timestamp: STUB_TIMESTAMP + 1,
         },
         buyRecordResult.Memory,
       );
@@ -643,7 +641,6 @@ describe('ArNS', async () => {
             { name: 'Years', value: '1' },
             { name: 'Fund-From', value: 'any' },
           ],
-          Timestamp: STUB_TIMESTAMP + 1,
         },
         buyRecordResult.Memory,
       );
@@ -654,7 +651,6 @@ describe('ArNS', async () => {
             { name: 'Action', value: 'Record' },
             { name: 'Name', value: 'test-name' },
           ],
-          Timestamp: STUB_TIMESTAMP + 1,
         },
         extendResult.Memory,
       );

--- a/tests/arns.test.mjs
+++ b/tests/arns.test.mjs
@@ -328,7 +328,6 @@ describe('ArNS', async () => {
                 { name: 'Quantity', value: `${650000000}` }, // delegate all of their balance
                 { name: 'Address', value: STUB_OPERATOR_ADDRESS }, // our gateway address
               ],
-              Timestamp: STUB_TIMESTAMP + 1,
             },
             memory,
           );
@@ -596,6 +595,7 @@ describe('ArNS', async () => {
         memory,
         transferQty: 700000000, // 600000000 for name purchase + 100000000 for extending the lease
         stakeQty: 650000000, // delegate most of their balance so that name purchase uses balance and stakes
+        timestamp: STUB_TIMESTAMP,
       });
 
       memory = stakeResult.memory;
@@ -612,6 +612,7 @@ describe('ArNS', async () => {
             { name: 'Process-Id', value: ''.padEnd(43, 'a') },
             { name: 'Fund-From', value: 'any' },
           ],
+          Timestamp: STUB_TIMESTAMP + 1,
         },
         memory,
       );
@@ -625,6 +626,7 @@ describe('ArNS', async () => {
             { name: 'Action', value: 'Record' },
             { name: 'Name', value: 'test-name' },
           ],
+          Timestamp: STUB_TIMESTAMP + 1,
         },
         buyRecordResult.Memory,
       );
@@ -641,6 +643,7 @@ describe('ArNS', async () => {
             { name: 'Years', value: '1' },
             { name: 'Fund-From', value: 'any' },
           ],
+          Timestamp: STUB_TIMESTAMP + 1,
         },
         buyRecordResult.Memory,
       );
@@ -651,6 +654,7 @@ describe('ArNS', async () => {
             { name: 'Action', value: 'Record' },
             { name: 'Name', value: 'test-name' },
           ],
+          Timestamp: STUB_TIMESTAMP + 1,
         },
         extendResult.Memory,
       );
@@ -727,6 +731,7 @@ describe('ArNS', async () => {
         transferQty: 3_100_000_000, // 60,000,0000 for name purchase + 2,500,000,000 for upgrading the name
         stakeQty: 3_100_000_000 - 50_000_000, // delegate most of their balance so that name purchase uses balance and stakes
         stakerAddress: STUB_ADDRESS,
+        timestamp: STUB_TIMESTAMP,
       });
       memory = stakeResult.memory;
 
@@ -833,6 +838,7 @@ describe('ArNS', async () => {
         },
         releaseNameResult.Memory,
       );
+
       // assert no error tag
       const auctionErrorTag = auctionResult.Messages?.[0]?.Tags?.find(
         (tag) => tag.name === 'Error',
@@ -999,6 +1005,7 @@ describe('ArNS', async () => {
       const balancesResult = await handle(
         {
           Tags: [{ name: 'Action', value: 'Balances' }],
+          Timestamp: bidTimestamp,
         },
         submitBidResult.Memory,
       );
@@ -1008,6 +1015,7 @@ describe('ArNS', async () => {
         initialRecord.purchasePrice +
         expectedRewardForProtocol;
       const balances = JSON.parse(balancesResult.Messages[0].Data);
+
       assert.equal(balances[initiator], expectedRewardForInitiator);
       assert.equal(balances[PROCESS_ID], expectedProtocolBalance);
       assert.equal(balances[bidderAddress], 0);
@@ -1019,6 +1027,7 @@ describe('ArNS', async () => {
         processId: ''.padEnd(43, 'a'),
         type: 'lease',
         years: 1,
+        timestamp: STUB_TIMESTAMP,
       });
 
       // tick the contract after the lease leaves its grace period
@@ -1039,6 +1048,7 @@ describe('ArNS', async () => {
             { name: 'Action', value: 'Auction-Info' },
             { name: 'Name', value: 'test-name' },
           ],
+          Timestamp: futureTimestamp,
         },
         tickResult.Memory,
       );
@@ -1089,7 +1099,7 @@ describe('ArNS', async () => {
             { name: 'Quantity', value: `${expectedPurchasePrice}` },
             { name: 'Cast', value: true },
           ],
-          Timestamp: bidTimestamp - 1,
+          Timestamp: bidTimestamp,
         },
         tickResult.Memory,
       );
@@ -1109,6 +1119,7 @@ describe('ArNS', async () => {
           transferQty: 0,
           stakeQty: expectedPurchasePrice,
           stakerAddress: bidderAddress,
+          timestamp: bidTimestamp,
         });
         memoryToUse = stakeResult.memory;
       }
@@ -1230,6 +1241,7 @@ describe('ArNS', async () => {
       const balancesResult = await handle(
         {
           Tags: [{ name: 'Action', value: 'Balances' }],
+          Timestamp: bidTimestamp,
         },
         submitBidResult.Memory,
       );
@@ -1499,6 +1511,7 @@ describe('ArNS', async () => {
     it('should paginate records correctly', async () => {
       // buy 3 records
       let buyRecordsMemory; // updated after each purchase
+      let lastTimestamp = STUB_TIMESTAMP;
       const recordsCount = 3;
       for (let i = 0; i < recordsCount; i++) {
         const buyRecordsResult = await handle(
@@ -1508,11 +1521,12 @@ describe('ArNS', async () => {
               { name: 'Name', value: `test-name-${i}` },
               { name: 'Process-Id', value: ''.padEnd(43, `${i}`) },
             ],
-            Timestamp: STUB_TIMESTAMP + i * 1000, // order of names is based on timestamp
+            Timestamp: lastTimestamp + i * 1000, // order of names is based on timestamp
           },
           buyRecordsMemory,
         );
         buyRecordsMemory = buyRecordsResult.Memory;
+        lastTimestamp = lastTimestamp + i * 1000;
       }
 
       // call the paginated records handler repeatedly until all records are fetched
@@ -1526,6 +1540,7 @@ describe('ArNS', async () => {
               { name: 'Cursor', value: cursor },
               { name: 'Limit', value: 1 },
             ],
+            Timestamp: lastTimestamp,
           },
           buyRecordsMemory,
         );
@@ -1599,6 +1614,7 @@ describe('ArNS', async () => {
             { name: 'Action', value: 'Gateway' },
             { name: 'Address', value: joinedGateway },
           ],
+          Timestamp: afterDistributionTimestamp,
         },
         firstTickAndDistribution.Memory,
       );
@@ -1618,7 +1634,7 @@ describe('ArNS', async () => {
       const transferMemory = await transfer({
         recipient: nonEligibleAddress,
         quantity: 200_000_000_000,
-        timestamp: afterDistributionTimestamp - 1,
+        timestamp: afterDistributionTimestamp,
         memory: firstTickAndDistribution.Memory,
       });
       arnsDiscountMemory = transferMemory;
@@ -1663,6 +1679,7 @@ describe('ArNS', async () => {
             { name: 'Intent', value: 'Buy-Record' },
             { name: 'Name', value: 'test-name' },
           ],
+          Timestamp: afterDistributionTimestamp,
         },
         arnsDiscountMemory,
       );
@@ -1856,6 +1873,7 @@ describe('ArNS', async () => {
                 From: nonEligibleAddress,
                 Owner: nonEligibleAddress,
                 Tags: upgradeToPermabuyTags,
+                Timestamp: upgradeToPermabuyTimestamp,
               },
               buyRecordResult.Memory,
             );
@@ -2005,7 +2023,7 @@ describe('ArNS', async () => {
           it('should not apply the discount on submit bid for a non-eligible gateway', async () => {
             const balanceBefore = await getBalance({
               memory: expiredRecordMemory,
-              timestamp: submitBidTimestamp - 1,
+              timestamp: submitBidTimestamp,
               address: nonEligibleAddress,
             });
             const result = await handle(

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -30,7 +30,7 @@ describe('GatewayRegistry', async () => {
 
   const delegateStake = async ({
     memory,
-    timestamp,
+    timestamp = STUB_TIMESTAMP,
     delegatorAddress,
     quantity,
     gatewayAddress,
@@ -41,6 +41,7 @@ describe('GatewayRegistry', async () => {
       recipient: delegatorAddress,
       quantity,
       memory,
+      timestamp,
     });
 
     const delegateResult = await handle(
@@ -578,6 +579,7 @@ describe('GatewayRegistry', async () => {
       const gateway = await getGateway({
         memory: sharedMemory,
         address: STUB_ADDRESS,
+        timestamp: STUB_TIMESTAMP,
       });
 
       // leave at timestamp
@@ -592,6 +594,7 @@ describe('GatewayRegistry', async () => {
       const leavingGateway = await getGateway({
         memory: leaveNetworkMemory,
         address: STUB_ADDRESS,
+        timestamp: leavingTimestamp,
       });
       assert.deepStrictEqual(leavingGateway, {
         ...gateway,
@@ -605,6 +608,7 @@ describe('GatewayRegistry', async () => {
         await getGatewayVaultsItems({
           memory: leaveNetworkMemory,
           gatewayAddress: STUB_ADDRESS,
+          timestamp: leavingTimestamp,
         }),
         [
           {
@@ -672,7 +676,6 @@ describe('GatewayRegistry', async () => {
         for (const delegateAddress of delegateAddresses) {
           const maybeDelegateResult = await delegateStake({
             memory: nextMemory,
-            timestamp: STUB_TIMESTAMP,
             delegatorAddress: delegateAddress,
             quantity: 500_000_000,
             gatewayAddress: STUB_ADDRESS,
@@ -976,6 +979,7 @@ describe('GatewayRegistry', async () => {
       const updatedGateway = await getGateway({
         address: STUB_ADDRESS,
         memory: decreaseStakeMemory,
+        timestamp: decreaseTimestamp,
       });
       assert.deepStrictEqual(updatedGateway, {
         ...gatewayBefore,
@@ -985,6 +989,7 @@ describe('GatewayRegistry', async () => {
         await getGatewayVaultsItems({
           memory: decreaseStakeMemory,
           gatewayAddress: STUB_ADDRESS,
+          timestamp: decreaseTimestamp,
         }),
         [
           {
@@ -1122,6 +1127,7 @@ describe('GatewayRegistry', async () => {
       const gatewayAfter = await getGateway({
         address: STUB_ADDRESS,
         memory: delegatedStakeMemory,
+        timestamp: delegationTimestamp,
       });
       assert.deepStrictEqual(gatewayAfter, {
         ...gatewayBefore,
@@ -1130,6 +1136,7 @@ describe('GatewayRegistry', async () => {
       const delegateItems = await getDelegatesItems({
         memory: delegatedStakeMemory,
         gatewayAddress: STUB_ADDRESS,
+        timestamp: delegationTimestamp,
       });
       assert.deepEqual(
         [
@@ -1161,6 +1168,7 @@ describe('GatewayRegistry', async () => {
       const gatewayBefore = await getGateway({
         address: STUB_ADDRESS,
         memory: delegatedStakeMemory,
+        timestamp: STUB_TIMESTAMP,
       });
       const { memory: decreaseStakeMemory } = await decreaseDelegateStake({
         memory: delegatedStakeMemory,
@@ -1174,6 +1182,7 @@ describe('GatewayRegistry', async () => {
       const gatewayAfter = await getGateway({
         address: STUB_ADDRESS,
         memory: decreaseStakeMemory,
+        timestamp: decreaseStakeTimestamp,
       });
       assert.deepStrictEqual(gatewayAfter, {
         ...gatewayBefore,
@@ -1182,6 +1191,7 @@ describe('GatewayRegistry', async () => {
       const delegateItems = await getDelegatesItems({
         memory: decreaseStakeMemory,
         gatewayAddress: STUB_ADDRESS,
+        timestamp: decreaseStakeTimestamp,
       });
       assert.deepEqual(
         [
@@ -1219,6 +1229,7 @@ describe('GatewayRegistry', async () => {
       const gatewayBefore = await getGateway({
         address: STUB_ADDRESS,
         memory: delegatedStakeMemory,
+        timestamp: STUB_TIMESTAMP,
       });
       const { memory: decreaseStakeMemory, result } =
         await decreaseDelegateStake({
@@ -1244,6 +1255,7 @@ describe('GatewayRegistry', async () => {
       const gatewayAfter = await getGateway({
         address: STUB_ADDRESS,
         memory: decreaseStakeMemory,
+        timestamp: decreaseStakeTimestamp,
       });
       assert.deepStrictEqual(gatewayAfter, gatewayBefore);
     });
@@ -1287,6 +1299,7 @@ describe('GatewayRegistry', async () => {
       const gatewayAfter = await getGateway({
         address: STUB_ADDRESS,
         memory: cancelWithdrawalMemory,
+        timestamp: decreaseStakeTimestamp,
       });
       // no changes to the gateway after a withdrawal is cancelled
       assert.deepStrictEqual(gatewayAfter, gatewayBefore);
@@ -1320,6 +1333,7 @@ describe('GatewayRegistry', async () => {
       const gatewayAfter = await getGateway({
         address: STUB_ADDRESS,
         memory: cancelWithdrawalMemory,
+        timestamp: decreaseStakeTimestamp,
       });
       // no changes to the gateway after a withdrawal is cancelled
       assert.deepStrictEqual(gatewayAfter, gatewayBefore);
@@ -1405,7 +1419,6 @@ describe('GatewayRegistry', async () => {
       const { memory: addGatewayMemory2 } = await joinNetwork({
         address: secondGatewayAddress,
         memory: sharedMemory,
-        timestamp: STUB_TIMESTAMP - 1,
       });
       let cursor;
       let fetchedGateways = [];
@@ -1459,7 +1472,6 @@ describe('GatewayRegistry', async () => {
       const { memory: addGatewayMemory2 } = await joinNetwork({
         address: secondGatewayAddress,
         memory: sharedMemory,
-        timestamp: STUB_TIMESTAMP - 1,
       });
 
       // Stake to both gateways
@@ -1503,6 +1515,7 @@ describe('GatewayRegistry', async () => {
               { name: 'Sort-Order', value: sortOrder },
               ...(cursor ? [{ name: 'Cursor', value: `${cursor}` }] : []),
             ],
+            Timestamp: STUB_TIMESTAMP + 2,
           },
           decreaseStakeMemory,
         );
@@ -1659,6 +1672,7 @@ describe('GatewayRegistry', async () => {
       const delegateItems = await getDelegatesItems({
         memory: delegatedStakeMemory,
         gatewayAddress: sourceAddress,
+        timestamp: STUB_TIMESTAMP,
       });
       assert.deepEqual(
         [
@@ -1784,6 +1798,7 @@ describe('GatewayRegistry', async () => {
       const delegateItems = await getDelegatesItems({
         memory: delegatedStakeMemory,
         gatewayAddress: sourceAddress,
+        timestamp: STUB_TIMESTAMP,
       });
       assert.deepStrictEqual(
         [
@@ -1827,6 +1842,7 @@ describe('GatewayRegistry', async () => {
         await getDelegatesItems({
           memory: redelegateStakeMemory,
           gatewayAddress: targetAddress,
+          timestamp: STUB_TIMESTAMP + 2,
         }),
         [
           {
@@ -1848,6 +1864,7 @@ describe('GatewayRegistry', async () => {
         await getDelegatesItems({
           memory: redelegateStakeMemory,
           gatewayAddress: sourceAddress,
+          timestamp: STUB_TIMESTAMP + 2,
         }),
         [],
       );

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -33,15 +33,18 @@ describe('handlers', async () => {
     const { Handlers: handlersList } = JSON.parse(handlers.Messages[0].Data);
     assert.ok(handlersList.includes('_eval'));
     assert.ok(handlersList.includes('_default'));
+    assert.ok(handlersList.includes('sanitize'));
     assert.ok(handlersList.includes('prune'));
 
     const evalIndex = handlersList.indexOf('_eval');
     const defaultIndex = handlersList.indexOf('_default');
+    const sanitizeIndex = handlersList.indexOf('sanitize');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 70; // TODO: update this if more handlers are added
+    const expectedHandlerCount = 71; // TODO: update this if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
-    assert.ok(pruneIndex === 2);
+    assert.ok(sanitizeIndex === 2);
+    assert.ok(pruneIndex === 3);
     assert.ok(
       handlersList.length === expectedHandlerCount,
       'should have ' +

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -63,6 +63,7 @@ export const transfer = async ({
   quantity = initialOperatorStake,
   memory = startMemory,
   cast = false,
+  timestamp = STUB_TIMESTAMP,
 } = {}) => {
   if (quantity === 0) {
     // Nothing to do
@@ -79,6 +80,7 @@ export const transfer = async ({
         { name: 'Quantity', value: quantity },
         { name: 'Cast', value: cast },
       ],
+      Timestamp: timestamp,
     },
     memory,
   );
@@ -93,11 +95,11 @@ export const joinNetwork = async ({
   tags = validGatewayTags,
   quantity = 100_000_000_000,
 }) => {
-  // give them the join network token amount
   const transferMemory = await transfer({
     recipient: address,
     quantity,
     memory,
+    timestamp,
   });
   const joinNetworkResult = await handle(
     {
@@ -131,6 +133,7 @@ export const setUpStake = async ({
     quantity: transferQty,
     memory,
     cast: true,
+    timestamp,
   });
 
   // Stake a gateway for the user to delegate to
@@ -138,7 +141,7 @@ export const setUpStake = async ({
     memory,
     address: gatewayAddress,
     tags: gatewayTags,
-    timestamp: timestamp - 1,
+    timestamp: timestamp,
   });
   assertNoResultError(joinNetworkResult);
   memory = joinNetworkResult.memory;
@@ -219,11 +222,15 @@ export const getDelegates = async ({
   };
 };
 
-export const getDelegatesItems = async ({ memory, gatewayAddress }) => {
+export const getDelegatesItems = async ({
+  memory,
+  gatewayAddress,
+  timestamp = STUB_TIMESTAMP,
+}) => {
   const { result } = await getDelegates({
     memory,
     from: STUB_ADDRESS,
-    timestamp: STUB_TIMESTAMP,
+    timestamp,
     gatewayAddress,
   });
   return JSON.parse(result.Messages?.[0]?.Data).items;
@@ -254,13 +261,18 @@ export const getVaults = async ({
   };
 };
 
-export const getGatewayVaultsItems = async ({ memory, gatewayAddress }) => {
+export const getGatewayVaultsItems = async ({
+  memory,
+  gatewayAddress,
+  timestamp = STUB_TIMESTAMP,
+}) => {
   const gatewayVaultsResult = await handle(
     {
       Tags: [
         { name: 'Action', value: 'Paginated-Gateway-Vaults' },
         { name: 'Address', value: gatewayAddress },
       ],
+      Timestamp: timestamp,
     },
     memory,
   );

--- a/tests/tick.test.mjs
+++ b/tests/tick.test.mjs
@@ -101,10 +101,8 @@ describe('Tick', async () => {
       buyRecordData.endTimestamp + 1000 * 60 * 60 * 24 * 14 + 1;
     const futureTickResult = await handle(
       {
-        Tags: [
-          { name: 'Action', value: 'Tick' },
-          { name: 'Timestamp', value: futureTimestamp.toString() },
-        ],
+        Tags: [{ name: 'Action', value: 'Tick' }],
+        Timestamp: futureTimestamp,
       },
       buyRecordResult.Memory,
     );
@@ -125,6 +123,7 @@ describe('Tick', async () => {
           { name: 'Action', value: 'Record' },
           { name: 'Name', value: 'test-name' },
         ],
+        Timestamp: futureTimestamp,
       },
       futureTickResult.Memory,
     );
@@ -140,6 +139,7 @@ describe('Tick', async () => {
           { name: 'Action', value: 'Auction-Info' },
           { name: 'Name', value: 'test-name' },
         ],
+        Timestamp: futureTimestamp,
       },
       futureTickResult.Memory,
     );
@@ -176,10 +176,7 @@ describe('Tick', async () => {
     );
 
     // assert no error tag
-    const errorTag = joinNetworkResult.Messages?.[0]?.Tags?.find(
-      (tag) => tag.name === 'Error',
-    );
-    assert.strictEqual(errorTag, undefined);
+    assertNoResultError(joinNetworkResult);
 
     // check the gateway record from contract
     const gateway = await handle(
@@ -223,10 +220,8 @@ describe('Tick', async () => {
     const futureTimestamp = leavingGatewayData.endTimestamp + 1;
     const futureTick = await handle(
       {
-        Tags: [
-          { name: 'Action', value: 'Tick' },
-          { name: 'Timestamp', value: futureTimestamp.toString() },
-        ],
+        Tags: [{ name: 'Action', value: 'Tick' }],
+        Timestamp: futureTimestamp,
       },
       leaveNetworkResult.Memory,
     );
@@ -238,6 +233,7 @@ describe('Tick', async () => {
           { name: 'Action', value: 'Gateway' },
           { name: 'Address', value: STUB_ADDRESS },
         ],
+        Timestamp: futureTimestamp,
       },
       futureTick.Memory,
     );
@@ -337,6 +333,7 @@ describe('Tick', async () => {
     const prunedVault = await handle(
       {
         Tags: [{ name: 'Action', value: 'Vault' }],
+        Timestamp: futureTimestamp,
       },
       futureTick.Memory,
     );
@@ -353,6 +350,7 @@ describe('Tick', async () => {
           { name: 'Action', value: 'Balance' },
           { name: 'Target', value: DEFAULT_HANDLE_OPTIONS.Owner },
         ],
+        Timestamp: futureTimestamp,
       },
       futureTick.Memory,
     );
@@ -655,6 +653,7 @@ describe('Tick', async () => {
     const delegateItems = await getDelegatesItems({
       memory: distributionTick.Memory,
       gatewayAddress: STUB_ADDRESS,
+      timestamp: distributionTimestamp,
     });
     assert.deepEqual(delegateItems, [
       {
@@ -691,6 +690,7 @@ describe('Tick', async () => {
       recipient: fundedUser,
       quantity: 100_000_000_000_000,
       memory: genesisEpochTick.Memory,
+      timestamp: genesisEpochStart,
     });
 
     // Buy records in this epoch
@@ -703,6 +703,7 @@ describe('Tick', async () => {
             { name: 'Name', value: 'test-name-' + i },
             { name: 'Purchase-Type', value: 'permabuy' },
           ],
+          Timestamp: genesisEpochStart,
         },
         buyRecordMemory,
       );
@@ -776,10 +777,7 @@ describe('Tick', async () => {
       const epochTimestamp = genesisEpochStart + (epochDurationMs + 1) * i;
       const { Memory } = await handle(
         {
-          Tags: [
-            { name: 'Action', value: 'Tick' },
-            { name: 'Timestamp', value: epochTimestamp.toString() },
-          ],
+          Tags: [{ name: 'Action', value: 'Tick' }],
           Timestamp: epochTimestamp,
         },
         tickMemory,


### PR DESCRIPTION
Adds `LastKnownMessageTimestamp` that is validated against the current message. Flagged some "invalid" states in our tests where timestamps were behind the latest. Additionally, it enforces input validation for all messages via a new `sanitize` handler. Note: we'll need to make sure this gets appended before `prune` on the `Handlers` object of the process.