### PR TITLE
fix(epochs): include prescribedObserversWithWeights to epoch handler

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -1890,11 +1890,14 @@ addEventingHandler(ActionMap.Record, utils.hasMatchingTag("Action", ActionMap.Re
 	Send(msg, recordNotice)
 end)
 
+-- TODO: this handler will not scale well as gateways and delegates increase, we should slice out the larger pieces (e.g. distributions should be fetched via a paginated handler)
 addEventingHandler(ActionMap.Epoch, utils.hasMatchingTag("Action", ActionMap.Epoch), function(msg)
 	-- check if the epoch number is provided, if not get the epoch number from the timestamp
 	local epochIndex = msg.Tags["Epoch-Index"] and tonumber(msg.Tags["Epoch-Index"])
 		or epochs.getEpochIndexForTimestamp(msg.Timestamp or msg.Tags.Timestamp)
 	local epoch = epochs.getEpoch(epochIndex)
+	-- populate the prescribed observers with weights
+	epoch.prescribedObservers = epochs.getPrescribedObserversWithWeightsForEpoch(epochIndex)
 	Send(msg, { Target = msg.From, Action = "Epoch-Notice", Data = json.encode(epoch) })
 end)
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -1896,8 +1896,11 @@ addEventingHandler(ActionMap.Epoch, utils.hasMatchingTag("Action", ActionMap.Epo
 	local epochIndex = msg.Tags["Epoch-Index"] and tonumber(msg.Tags["Epoch-Index"])
 		or epochs.getEpochIndexForTimestamp(msg.Timestamp or msg.Tags.Timestamp)
 	local epoch = epochs.getEpoch(epochIndex)
+	-- TODO: this check can be removed after 14 days of release once old epochs are pruned
+	if not epoch.prescribedObservers or not next(epoch.prescribedObservers).gatewayAddress then
+		epoch.prescribedObservers = epochs.getPrescribedObserversWithWeightsForEpoch(epochIndex)
+	end
 	-- populate the prescribed observers with weights
-	epoch.prescribedObservers = epochs.getPrescribedObserversWithWeightsForEpoch(epochIndex)
 	Send(msg, { Target = msg.From, Action = "Epoch-Notice", Data = json.encode(epoch) })
 end)
 

--- a/tests/epochs.test.mjs
+++ b/tests/epochs.test.mjs
@@ -55,9 +55,18 @@ describe('epochs', () => {
         startHeight: 1,
         distributionTimestamp:
           firstEpochStartTimestamp + epochLength + distributionDelay,
-        prescribedObservers: {
-          [STUB_ADDRESS]: STUB_OPERATOR_ADDRESS,
-        },
+        prescribedObservers: [
+          {
+            observerAddress: STUB_ADDRESS,
+            gatewayAddress: STUB_OPERATOR_ADDRESS,
+            stakeWeight: 1,
+            gatewayRewardRatioWeight: 1,
+            observerRewardRatioWeight: 1,
+            compositeWeight: 4,
+            normalizedCompositeWeight: 1,
+            tenureWeight: 4,
+          },
+        ],
         prescribedNames: ['prescribed-name'],
         observations: {
           failureSummaries: [],

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -1229,6 +1229,7 @@ describe('GatewayRegistry', async () => {
       const { memory: addGatewayMemory2 } = await joinNetwork({
         address: secondGatewayAddress,
         memory: sharedMemory,
+        timestamp: STUB_TIMESTAMP + 1, // join the network 1ms after the first gateway
       });
       let cursor;
       let fetchedGateways = [];
@@ -1239,9 +1240,12 @@ describe('GatewayRegistry', async () => {
               { name: 'Action', value: 'Paginated-Gateways' },
               { name: 'Cursor', value: cursor },
               { name: 'Limit', value: '1' },
+              { name: 'Sort-By', value: 'startTimestamp' },
+              { name: 'Sort-Order', value: 'asc' },
             ],
           },
           memory: addGatewayMemory2,
+          timestamp: STUB_TIMESTAMP + 1,
         });
         // parse items, nextCursor
         const { items, nextCursor, hasMore, sortBy, sortOrder, totalItems } =
@@ -1249,7 +1253,7 @@ describe('GatewayRegistry', async () => {
         assert.equal(totalItems, 2);
         assert.equal(items.length, 1);
         assert.equal(sortBy, 'startTimestamp');
-        assert.equal(sortOrder, 'desc');
+        assert.equal(sortOrder, 'asc'); // older gateways are first
         assert.equal(hasMore, !!nextCursor);
         cursor = nextCursor;
         fetchedGateways.push(...items);

--- a/tests/tick.test.mjs
+++ b/tests/tick.test.mjs
@@ -401,9 +401,18 @@ describe('Tick', async () => {
         failureSummaries: [],
         reports: [],
       },
-      prescribedObservers: {
-        [STUB_ADDRESS]: STUB_ADDRESS,
-      },
+      prescribedObservers: [
+        {
+          observerAddress: STUB_ADDRESS,
+          gatewayAddress: STUB_ADDRESS,
+          stakeWeight: 3,
+          gatewayRewardRatioWeight: 1,
+          observerRewardRatioWeight: 1,
+          compositeWeight: 12,
+          normalizedCompositeWeight: 1,
+          tenureWeight: 4,
+        },
+      ],
       prescribedNames: [], // no names in the network
       distributions: {
         totalEligibleGateways: 1,
@@ -446,7 +455,7 @@ describe('Tick', async () => {
     // assert no error tag
     assertNoResultError(distributionTick);
 
-    // check the rewards were distributed correctly
+    // check the rewards were distributed correctly and weights are updated
     const distributedEpochData = await getEpoch({
       memory: distributionTick.memory,
       timestamp: distributionTimestamp,
@@ -473,6 +482,13 @@ describe('Tick', async () => {
           [STUB_ADDRESS]: reportTxId,
         },
       },
+      prescribedObservers: [
+        {
+          ...epochData.prescribedObservers[0],
+          compositeWeight: 22,
+          stakeWeight: 5.5,
+        },
+      ],
     });
     // assert the new epoch was created
     const newEpoch = await getEpoch({


### PR DESCRIPTION
This avoids a breaking change that impacts the network portal and ar-io-sdk types