### PR TITLE
PE-7211: Check for invariants at conclusion of almost all integration tests

### DIFF
--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -97,6 +97,7 @@ export function assertValidSupplyEventData(result) {
 }
 
 export const getBalances = async ({ memory, timestamp = STUB_TIMESTAMP }) => {
+  assert(memory, 'Memory is required');
   const result = await handle({
     options: {
       Tags: [{ name: 'Action', value: 'Balances' }],
@@ -105,6 +106,11 @@ export const getBalances = async ({ memory, timestamp = STUB_TIMESTAMP }) => {
     memory,
   });
 
+  const balancesData = result.Messages?.[0]?.Data;
+  if (!balancesData) {
+    const { Memory, ...rest } = result;
+    assert(false, `Something went wrong: ${JSON.stringify(rest, null, 2)}`);
+  }
   const balances = JSON.parse(result.Messages?.[0]?.Data);
   return balances;
 };

--- a/tests/invariants.mjs
+++ b/tests/invariants.mjs
@@ -25,7 +25,7 @@ function assertValidTimestampsAtTimestamp({
   );
   assert(
     endTimestamp === null || endTimestamp > startTimestamp,
-    `Invariant violated: endTimestamp of ${endTimestamp} for vault ${address}`,
+    `Invariant violated: endTimestamp of ${endTimestamp} is not greater than startTimestamp ${startTimestamp}`,
   );
 }
 

--- a/tests/tick.test.mjs
+++ b/tests/tick.test.mjs
@@ -4,8 +4,6 @@ import assert from 'node:assert';
 import {
   DEFAULT_HANDLE_OPTIONS,
   STUB_ADDRESS,
-  validGatewayTags,
-  PROCESS_OWNER,
   PROCESS_ID,
   STUB_TIMESTAMP,
   INITIAL_OPERATOR_STAKE,
@@ -47,7 +45,7 @@ describe('Tick', async () => {
 
   afterEach(async () => {
     await assertNoInvariants({
-      timestamp: STUB_TIMESTAMP,
+      timestamp: genesisEpochStart + 1000 * 60 * 60 * 24 * 365,
       memory: sharedMemory,
     });
   });
@@ -137,6 +135,7 @@ describe('Tick', async () => {
       initiator: PROCESS_ID,
       premiumMultiplier: 50,
     });
+    sharedMemory = returnedNameData.Memory;
   });
 
   it('should prune gateways that are expired', async () => {
@@ -186,6 +185,7 @@ describe('Tick', async () => {
     });
 
     assert.deepEqual(undefined, prunedGateway);
+    sharedMemory = futureTick.memory;
   });
 
   // vaulting is not working as expected, need to fix before enabling this test
@@ -306,6 +306,7 @@ describe('Tick', async () => {
     });
     const balanceData = JSON.parse(ownerBalance.Messages[0].Data);
     assert.equal(balanceData, balanceBeforeData);
+    sharedMemory = ownerBalance.Memory;
   });
 
   /**
@@ -555,6 +556,7 @@ describe('Tick', async () => {
         address: delegateAddress,
       },
     ]);
+    sharedMemory = distributionTick.memory;
   });
 
   it('should not increase demandFactor and baseRegistrationFee when records are bought until the end of the epoch', async () => {
@@ -643,6 +645,7 @@ describe('Tick', async () => {
       timestamp: firstEpochEndTimestamp + 1,
     });
     assert.equal(firstEpochEndDemandFactorResult, 1.0500000000000000444);
+    sharedMemory = firstEpochEndTick.Memory;
   });
 
   it('should reset to baseRegistrationFee when demandFactor is 0.5 for consecutive epochs', async () => {
@@ -701,5 +704,6 @@ describe('Tick', async () => {
 
     assert.equal(demandFactorAfterFeeAdjustment, 1);
     assert.equal(baseFeeAfterConsecutiveTicksWithNoPurchases, 300_000_000);
+    sharedMemory = tickMemory;
   });
 });

--- a/tests/vaults.test.mjs
+++ b/tests/vaults.test.mjs
@@ -18,6 +18,7 @@ import { assertNoInvariants } from './invariants.mjs';
 
 describe('Vaults', async () => {
   let sharedMemory = startMemory;
+  let endingMemory;
   beforeEach(async () => {
     const { Memory: totalTokenSupplyMemory } = await totalTokenSupply({
       memory: startMemory,
@@ -28,7 +29,7 @@ describe('Vaults', async () => {
   afterEach(async () => {
     await assertNoInvariants({
       timestamp: STUB_TIMESTAMP,
-      memory: sharedMemory,
+      memory: endingMemory,
     });
   });
 
@@ -111,6 +112,7 @@ describe('Vaults', async () => {
         createVaultResultData.endTimestamp,
         createVaultResult.startTimestamp + lockLengthMs,
       );
+      endingMemory = createVaultResult.Memory;
     });
 
     it('should throw an error if vault size is too small', async () => {
@@ -154,6 +156,7 @@ describe('Vaults', async () => {
         balanceAfterVault.Messages[0].Data,
       );
       assert.deepEqual(balanceAfterVaultData, balanceBeforeData);
+      endingMemory = balanceAfterVault.Memory;
     });
   });
 
@@ -212,6 +215,7 @@ describe('Vaults', async () => {
         createVaultResultData.balance,
         quantity,
       );
+      endingMemory = extendVaultResult.Memory;
     });
   });
 
@@ -273,6 +277,7 @@ describe('Vaults', async () => {
         increaseVaultBalanceResultData.balance,
         createVaultResultData.balance + quantity,
       );
+      endingMemory = increaseVaultBalanceResult.Memory;
     });
   });
 
@@ -330,6 +335,7 @@ describe('Vaults', async () => {
         createdVaultData.endTimestamp,
         STUB_TIMESTAMP + lockLengthMs,
       );
+      endingMemory = createVaultedTransferResult.Memory;
     });
 
     it('should fail if the vault size is too small', async () => {
@@ -353,6 +359,7 @@ describe('Vaults', async () => {
           'Invalid quantity. Must be integer greater than or equal to 100000000 mARIO',
         ),
       );
+      endingMemory = createVaultedTransferResult.Memory;
     });
 
     it('should fail if the recipient address is invalid and Allow-Unsafe-Addresses is not provided', async () => {
@@ -373,6 +380,7 @@ describe('Vaults', async () => {
       );
       assert.ok(errorTag);
       assert(errorTag.value.includes('Invalid recipient'));
+      endingMemory = createVaultedTransferResult.Memory;
     });
 
     it('should create a vault for the recipient with an invalid address and Allow-Unsafe-Addresses is provided', async () => {
@@ -401,6 +409,7 @@ describe('Vaults', async () => {
         createdVaultData.endTimestamp,
         STUB_TIMESTAMP + lockLengthMs,
       );
+      endingMemory = createVaultedTransferResult.Memory;
     });
   });
 
@@ -444,7 +453,7 @@ describe('Vaults', async () => {
       let cursor = '';
       let fetchedVaults = [];
       while (true) {
-        const { result: paginatedVaultsResult } = await getVaults({
+        const { result: paginatedVaultsResult, memory } = await getVaults({
           memory: paginatedVaultMemory,
           cursor,
           limit: 1,
@@ -461,6 +470,7 @@ describe('Vaults', async () => {
         assert.equal(hasMore, !!nextCursor);
         cursor = nextCursor;
         fetchedVaults.push(...items);
+        endingMemory = memory;
         if (!cursor) break;
       }
 
@@ -486,7 +496,7 @@ describe('Vaults', async () => {
       let cursor = '';
       let fetchedVaults = [];
       while (true) {
-        const { result: paginatedVaultsResult } = await getVaults({
+        const { result: paginatedVaultsResult, memory } = await getVaults({
           memory: paginatedVaultMemory,
           cursor,
           limit: 1,
@@ -505,6 +515,7 @@ describe('Vaults', async () => {
         assert.equal(hasMore, !!nextCursor);
         cursor = nextCursor;
         fetchedVaults.push(...items);
+        endingMemory = memory;
         if (!cursor) break;
       }
 


### PR DESCRIPTION
After getting queasy with the reuse of sharedMemory in a few test files, I opted for the introduction of `endingMemory` in newly updated/integration tests.