### PR TITLE
chore(cleanup): address TODOs PE-7339

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,6 @@ dependencies = {
 
 ### Deployment
 
-TODO:
+Merging to develop or main will evolve the devnet or testnet contract to the next version. The script managing the logic is located at `tools/evolve.mjs`, which uses aoconnect to perform an `Eval` action. The deployment process is automated using Github Actions.
 
 [contract whitepaper]: https://ar.io/whitepaper

--- a/spec/balances_spec.lua
+++ b/spec/balances_spec.lua
@@ -3,6 +3,7 @@ local balances = require("balances")
 local testAddress1 = "test-this-is-valid-arweave-wallet-address-1"
 local testAddress2 = "test-this-is-valid-arweave-wallet-address-2"
 local testAddressEth = "0xFCAd0B19bB29D4674531d6f115237E16AfCE377c"
+local unsafeAddress = "not-a-real-address"
 
 describe("balances", function()
 	before_each(function()
@@ -16,7 +17,7 @@ describe("balances", function()
 	end)
 
 	it("should transfer tokens", function()
-		local result = balances.transfer(testAddress2, testAddress1, 100)
+		local result = balances.transfer(testAddress2, testAddress1, 100, false)
 		assert.are.same(result[testAddress2], _G.Balances[testAddress2])
 		assert.are.same(result[testAddress1], _G.Balances[testAddress1])
 		assert.are.equal(100, _G.Balances[testAddress2])
@@ -24,10 +25,26 @@ describe("balances", function()
 	end)
 
 	it("should transfer tokens between Arweave and ETH addresses", function()
-		local result = balances.transfer(testAddressEth, testAddress1, 100)
+		local result = balances.transfer(testAddressEth, testAddress1, 100, false)
 		assert.are.same(result[testAddressEth], _G.Balances[testAddressEth])
 		assert.are.same(result[testAddress1], _G.Balances[testAddress1])
 		assert.are.equal(100, _G.Balances[testAddressEth])
+		assert.are.equal(0, _G.Balances[testAddress1])
+	end)
+
+	it("should fail when transferring to unsafe address and unsafe flag is true", function()
+		local status, result = pcall(balances.transfer, unsafeAddress, testAddress1, 100, false)
+		assert.is_false(status)
+		assert.match("Invalid recipient", result)
+		assert.are.equal(nil, _G.Balances[unsafeAddress])
+		assert.are.equal(100, _G.Balances[testAddress1])
+	end)
+
+	it("should not fail when transferring to unsafe address and unsafe flag is false", function()
+		local result = balances.transfer(unsafeAddress, testAddress1, 100, true)
+		assert.are.same(result[unsafeAddress], _G.Balances[unsafeAddress])
+		assert.are.same(result[testAddress1], _G.Balances[testAddress1])
+		assert.are.equal(100, _G.Balances[unsafeAddress])
 		assert.are.equal(0, _G.Balances[testAddress1])
 	end)
 

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -123,6 +123,14 @@ describe("epochs", function()
 				settings = testSettings,
 				status = "joined",
 				observerAddress = "observerAddress",
+				weights = {
+					normalizedCompositeWeight = 1,
+					stakeWeight = 1,
+					tenureWeight = 1,
+					gatewayRewardRatioWeight = 1,
+					observerRewardRatioWeight = 1,
+					compositeWeight = 1,
+				},
 			}
 			local expectation = {
 				["observerAddress"] = "test-this-is-valid-arweave-wallet-address-1",
@@ -158,6 +166,14 @@ describe("epochs", function()
 					settings = testSettings,
 					status = "joined",
 					observerAddress = "observer-address-" .. i,
+					weights = {
+						normalizedCompositeWeight = 1,
+						stakeWeight = 1,
+						tenureWeight = 1,
+						gatewayRewardRatioWeight = 1,
+						observerRewardRatioWeight = 1,
+						compositeWeight = 1,
+					},
 				}
 				-- note - ordering of keys is not guaranteed when insert into maps
 				_G.GatewayRegistry["observer" .. i] = gateway
@@ -304,6 +320,14 @@ describe("epochs", function()
 						settings = testSettings,
 						status = "joined",
 						observerAddress = "test-this-is-valid-arweave-observer-address-1",
+						weights = {
+							normalizedCompositeWeight = 1,
+							stakeWeight = 1,
+							tenureWeight = 1,
+							gatewayRewardRatioWeight = 1,
+							observerRewardRatioWeight = 1,
+							compositeWeight = 1,
+						},
 					},
 					["test-this-is-valid-arweave-wallet-address-2"] = {
 						operatorStake = gar.getSettings().operators.minStake,
@@ -323,6 +347,14 @@ describe("epochs", function()
 						settings = testSettings,
 						status = "joined",
 						observerAddress = "test-this-is-valid-arweave-observer-address-2",
+						weights = {
+							normalizedCompositeWeight = 1,
+							stakeWeight = 1,
+							tenureWeight = 1,
+							gatewayRewardRatioWeight = 1,
+							observerRewardRatioWeight = 1,
+							compositeWeight = 1,
+						},
 					},
 					["test-this-is-valid-arweave-wallet-address-3"] = {
 						operatorStake = gar.getSettings().operators.minStake,
@@ -342,6 +374,14 @@ describe("epochs", function()
 						settings = testSettings,
 						status = "joined",
 						observerAddress = "test-this-is-valid-arweave-observer-address-3",
+						weights = {
+							normalizedCompositeWeight = 1,
+							stakeWeight = 1,
+							tenureWeight = 1,
+							gatewayRewardRatioWeight = 1,
+							observerRewardRatioWeight = 1,
+							compositeWeight = 1,
+						},
 					},
 					["test-this-is-valid-arweave-wallet-address-4"] = {
 						operatorStake = gar.getSettings().operators.minStake,
@@ -362,6 +402,14 @@ describe("epochs", function()
 						settings = testSettings,
 						status = "leaving", -- leaving, so it is not eligible to receive stats from this epoch
 						observerAddress = "test-this-is-valid-arweave-observer-address-4",
+						weights = {
+							normalizedCompositeWeight = 1,
+							stakeWeight = 1,
+							tenureWeight = 1,
+							gatewayRewardRatioWeight = 1,
+							observerRewardRatioWeight = 1,
+							compositeWeight = 1,
+						},
 					},
 				}
 				_G.Epochs[0].prescribedObservers = {

--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -334,15 +334,7 @@ describe("gar", function()
 				vaults = {},
 				delegates = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = {
 					allowDelegatedStaking = testSettings.allowDelegatedStaking,
 					delegateRewardShareRatio = testSettings.delegateRewardShareRatio,
@@ -574,15 +566,7 @@ describe("gar", function()
 				totalDelegatedStake = minDelegatedStake,
 				vaults = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
@@ -593,6 +577,7 @@ describe("gar", function()
 						vaults = {},
 					},
 				},
+				weights = testGateway.weights,
 			}
 			local expectedSettings = utils.deepCopy(testSettings)
 			expectedSettings.allowedDelegatesLookup = {
@@ -632,18 +617,11 @@ describe("gar", function()
 				},
 				startTimestamp = startTimestamp,
 				endTimestamp = operatorLeaveLengthMs,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = expectedSettings,
 				status = "leaving",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			})
 		end)
 	end)
@@ -657,18 +635,11 @@ describe("gar", function()
 				vaults = {},
 				delegates = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			}
 			local result = gar.increaseOperatorStake(stubGatewayAddress, 1000)
 			assert.are.equal(_G.Balances[stubGatewayAddress], 0)
@@ -678,18 +649,11 @@ describe("gar", function()
 				vaults = {},
 				delegates = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			})
 		end)
 	end)
@@ -702,18 +666,11 @@ describe("gar", function()
 				vaults = {},
 				delegates = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			}
 			local status, result =
 				pcall(gar.decreaseOperatorStake, stubGatewayAddress, 1000, startTimestamp, stubMessageId)
@@ -730,18 +687,11 @@ describe("gar", function()
 				},
 				delegates = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			})
 		end)
 		it("should instantly withdraw operator stake with expedited withdrawal fee", function()
@@ -756,18 +706,11 @@ describe("gar", function()
 				vaults = {},
 				delegates = {},
 				startTimestamp = startTimestamp,
-				stats = {
-					prescribedEpochCount = 0,
-					observedEpochCount = 0,
-					totalEpochCount = 0,
-					passedEpochCount = 0,
-					failedEpochCount = 0,
-					failedConsecutiveEpochs = 0,
-					passedConsecutiveEpochs = 0,
-				},
+				stats = testGateway.stats,
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			}
 
 			local status, result = pcall(
@@ -799,6 +742,7 @@ describe("gar", function()
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			}
 
 			local status, result = pcall(
@@ -837,6 +781,7 @@ describe("gar", function()
 				settings = testSettings,
 				status = "leaving",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			}
 
 			local status, result =
@@ -859,6 +804,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}
 			local newObserverWallet = stubGatewayAddress
 			local updatedSettings = {
@@ -883,6 +829,7 @@ describe("gar", function()
 				stats = testGateway.stats,
 				settings = updatedSettings,
 				status = testGateway.status,
+				weights = testGateway.weights,
 			}
 			local result = gar.updateGatewaySettings(
 				stubGatewayAddress,
@@ -907,6 +854,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}
 			local newObserverWallet = stubGatewayAddress
 			local inputUpdatedSettings = {
@@ -941,6 +889,7 @@ describe("gar", function()
 				stats = testGateway.stats,
 				settings = expectedSettings,
 				status = testGateway.status,
+				weights = testGateway.weights,
 			}
 			local result = gar.updateGatewaySettings(
 				stubGatewayAddress,
@@ -965,6 +914,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}
 
 			local updatedServices = {
@@ -992,6 +942,7 @@ describe("gar", function()
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
 				services = updatedServices,
+				weights = testGateway.weights,
 			}, result)
 		end)
 
@@ -1006,6 +957,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = "leaving",
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}
 
 			local updatedSettings = {
@@ -1050,6 +1002,7 @@ describe("gar", function()
 					settings = settings,
 					status = testGateway.status,
 					observerAddress = testGateway.observerAddress,
+					weights = testGateway.weights,
 				}
 
 				local updatedSettings = {
@@ -1410,6 +1363,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}
 
 			local status, err = pcall(
@@ -1445,6 +1399,15 @@ describe("gar", function()
 				_G.Balances[from] = 0
 
 				_G.GatewayRegistry[gatewayAddress] = {
+					startTimestamp = testGateway.startTimestamp,
+					stats = testGateway.stats,
+					services = testGateway.services,
+					settings = testGateway.settings,
+					status = testGateway.status,
+					observerAddress = testGateway.observerAddress,
+					weights = testGateway.weights,
+					delegates = {},
+					totalDelegatedStake = 0,
 					operatorStake = 2000,
 					vaults = {
 						[vaultId] = {
@@ -1490,6 +1453,15 @@ describe("gar", function()
 					_G.Balances[from] = 0
 
 					_G.GatewayRegistry[gatewayAddress] = {
+						startTimestamp = testGateway.startTimestamp,
+						stats = testGateway.stats,
+						services = testGateway.services,
+						settings = testGateway.settings,
+						status = testGateway.status,
+						observerAddress = testGateway.observerAddress,
+						weights = testGateway.weights,
+						delegates = {},
+						totalDelegatedStake = 0,
 						operatorStake = 2000,
 						vaults = {
 							[vaultId] = {
@@ -1540,6 +1512,15 @@ describe("gar", function()
 				local currentTimestamp = 1000000
 
 				_G.GatewayRegistry[from] = {
+					startTimestamp = testGateway.startTimestamp,
+					stats = testGateway.stats,
+					services = testGateway.services,
+					settings = testGateway.settings,
+					status = testGateway.status,
+					observerAddress = testGateway.observerAddress,
+					weights = testGateway.weights,
+					delegates = {},
+					totalDelegatedStake = 0,
 					operatorStake = 2000,
 					vaults = {},
 				}
@@ -1559,6 +1540,14 @@ describe("gar", function()
 				local currentTimestamp = 1000000
 
 				_G.GatewayRegistry[from] = {
+					startTimestamp = testGateway.startTimestamp,
+					stats = testGateway.stats,
+					services = testGateway.services,
+					settings = testGateway.settings,
+					observerAddress = testGateway.observerAddress,
+					weights = testGateway.weights,
+					delegates = {},
+					totalDelegatedStake = 0,
 					operatorStake = 2000,
 					status = "leaving",
 					vaults = {
@@ -1586,6 +1575,15 @@ describe("gar", function()
 				local currentTimestamp = vaultTimestamp - 1 -- Negative elapsed time
 
 				_G.GatewayRegistry[from] = {
+					startTimestamp = testGateway.startTimestamp,
+					stats = testGateway.stats,
+					services = testGateway.services,
+					settings = testGateway.settings,
+					status = testGateway.status,
+					observerAddress = testGateway.observerAddress,
+					weights = testGateway.weights,
+					delegates = {},
+					totalDelegatedStake = 0,
 					operatorStake = 2000,
 					vaults = {
 						[vaultId] = {
@@ -1643,6 +1641,7 @@ describe("gar", function()
 						settings = testGateway.settings,
 						status = testGateway.status,
 						observerAddress = testGateway.observerAddress,
+						weights = testGateway.weights,
 					}
 
 					local withdrawalResult =
@@ -1703,6 +1702,7 @@ describe("gar", function()
 						settings = testGateway.settings,
 						status = testGateway.status,
 						observerAddress = testGateway.observerAddress,
+						weights = testGateway.weights,
 					}
 
 					local withdrawalResult =
@@ -1769,6 +1769,7 @@ describe("gar", function()
 						settings = testGateway.settings,
 						status = testGateway.status,
 						observerAddress = testGateway.observerAddress,
+						weights = testGateway.weights,
 					}
 
 					local withdrawalResult =
@@ -1820,6 +1821,7 @@ describe("gar", function()
 					settings = testGateway.settings,
 					status = testGateway.status,
 					observerAddress = testGateway.observerAddress,
+					weights = testGateway.weights,
 				}
 
 				local status, err = pcall(
@@ -1866,6 +1868,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}
 			local currentTimestamp = 123456
 			local status, err = pcall(gar.slashOperatorStake, stubGatewayAddress, slashAmount, currentTimestamp)
@@ -1884,6 +1887,7 @@ describe("gar", function()
 				settings = testGateway.settings,
 				status = testGateway.status,
 				observerAddress = testGateway.observerAddress,
+				weights = testGateway.weights,
 			}, _G.GatewayRegistry[stubGatewayAddress])
 			assert.are.equal(slashAmount, _G.Balances[ao.id])
 		end)
@@ -1909,6 +1913,7 @@ describe("gar", function()
 				settings = testSettings,
 				status = "joined",
 				observerAddress = stubObserverAddress,
+				weights = testGateway.weights,
 			}
 			local timestamp = 100
 			local expectedTenureWeight = timestamp / gar.getSettings().observers.tenureWeightPeriod
@@ -2359,6 +2364,10 @@ describe("gar", function()
 			_G.GatewayRegistry[stubRandomAddress].weights = {
 				tenureWeight = 0.5,
 				gatewayRewardRatioWeight = 0.85,
+				stakeWeight = 0,
+				observerRewardRatioWeight = 0,
+				compositeWeight = 0,
+				normalizedCompositeWeight = 0,
 			}
 			local result = gar.isEligibleForArNSDiscount(stubRandomAddress)
 			assert.is_false(result)
@@ -2369,6 +2378,10 @@ describe("gar", function()
 			_G.GatewayRegistry[stubRandomAddress].weights = {
 				tenureWeight = 1,
 				gatewayRewardRatioWeight = 0.84,
+				stakeWeight = 0,
+				observerRewardRatioWeight = 0,
+				compositeWeight = 0,
+				normalizedCompositeWeight = 0,
 			}
 			local result = gar.isEligibleForArNSDiscount(stubRandomAddress)
 			assert.is_false(result)
@@ -2379,6 +2392,10 @@ describe("gar", function()
 			_G.GatewayRegistry[stubRandomAddress].weights = {
 				tenureWeight = 1,
 				gatewayRewardRatioWeight = 0.85,
+				stakeWeight = 0,
+				observerRewardRatioWeight = 0,
+				compositeWeight = 0,
+				normalizedCompositeWeight = 0,
 			}
 			_G.GatewayRegistry[stubRandomAddress].status = "joined"
 			local result = gar.isEligibleForArNSDiscount(stubRandomAddress)

--- a/src/ao_event.lua
+++ b/src/ao_event.lua
@@ -1,7 +1,20 @@
 local utils = require("utils")
 local json = require("json")
 
--- Factory function for creating an "AOEvent"
+--- @class AOEvent
+--- @field data table<string, any> The data table holding the event fields.
+--- @field sampleRate number|nil Optional sample rate.
+--- @field addField fun(self: AOEvent, key: string, value: any): AOEvent Adds a single field to the event.
+--- @field addFields fun(self: AOEvent, fields: table<string, any>): AOEvent Adds multiple fields to the event.
+--- @field addFieldsIfExist fun(self: AOEvent, table: table<string, any>, fields: table<string>): AOEvent Adds specific fields if they exist in the given table.
+--- @field addFieldsWithPrefixIfExist fun(self: AOEvent, srcTable: table<string, any>, prefix: string, fields: table<string>): AOEvent
+---  Adds fields with a prefix if they exist in the source table.
+--- @field printEvent fun(self: AOEvent): nil Prints the event in JSON format.
+--- @field toJSON fun(self: AOEvent): string Converts the event to a JSON string.
+
+--- Factory function for creating an "AOEvent"
+--- @param initialData table<string, any> Optional initial data to populate the event with.
+--- @returns AOEvent
 local function AOEvent(initialData)
 	local event = {
 		sampleRate = nil, -- Optional sample rate

--- a/src/ario_event.lua
+++ b/src/ario_event.lua
@@ -1,8 +1,12 @@
 local AOEvent = require("ao_event")
 local utils = require("utils")
 
--- TODO: RENAME TO ARIOEvent
--- Convenience factory function for prepopulating analytic and msg fields into AOEvents
+--- @alias ARIOEvent AOEvent
+
+--- Convenience factory function for pre populating analytic and msg fields into AOEvents
+--- @param msg table
+--- @param initialData table<string, any> Optional initial data to populate the event with.
+--- @returns ARIOEvent
 local function ARIOEvent(msg, initialData)
 	local event = AOEvent({
 		Cron = msg.Cron or false,

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -352,8 +352,6 @@ end
 
 function arns.getProcessIdForRecord(name)
 	local record = arns.getRecord(name)
-	-- TODO: Could assert for type safety -- but on pruneState flow, the record does not exist
-	-- assert(record, "Name is not registered: " .. name)
 	return record ~= nil and record.processId or nil
 end
 

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -23,6 +23,8 @@ constants.maximumRewardRate = 0.001
 constants.minimumRewardRate = 0.0005
 constants.rewardDecayStartEpoch = 365
 constants.rewardDecayLastEpoch = 547
+constants.observerRewardRatio = 0.1
+constants.gatewayOperatorRewardRatio = 0.9
 
 -- GAR
 constants.DEFAULT_UNDERNAME_COUNT = 10

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -462,7 +462,7 @@ function epochs.saveObservations(observerAddress, reportTxId, failedGatewayAddre
 
 	local epoch = epochs.getEpoch(epochIndex)
 
-	-- check if this is the first report filed in this epoch (TODO: use start or end?)
+	-- check if this is the first report filed in this epoch
 	if epoch.observations == nil then
 		epoch.observations = {
 			failureSummaries = {},

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -339,11 +339,9 @@ end
 --- @param timestamp number The timestamp
 --- @return number # 	The epoch index
 function epochs.getEpochIndexForTimestamp(timestamp)
-	--- TODO: is this conversion still necessary? Confirm timestamps from the SU are unix and milliseconds and remove this
-	local timestampInMS = utils.checkAndConvertTimestampToMs(timestamp)
 	local epochZeroStartTimestamp = epochs.getSettings().epochZeroStartTimestamp
 	local epochLengthMs = epochs.getSettings().durationMs
-	local epochIndex = math.floor((timestampInMS - epochZeroStartTimestamp) / epochLengthMs)
+	local epochIndex = math.floor((timestamp - epochZeroStartTimestamp) / epochLengthMs)
 	return epochIndex
 end
 
@@ -526,9 +524,11 @@ function epochs.computeTotalEligibleRewardsForEpoch(epochIndex, prescribedObserv
 	local protocolBalance = balances.getBalance(ao.id)
 	local rewardRate = epochs.getRewardRateForEpoch(epochIndex)
 	local totalEligibleRewards = math.floor(protocolBalance * rewardRate)
-	local eligibleGatewayReward = math.floor(totalEligibleRewards * 0.90 / #activeGatewayAddresses) -- TODO: make these setting variables
-	local eligibleObserverReward =
-		math.floor(totalEligibleRewards * 0.10 / utils.lengthOfTable(prescribedObserversLookup)) -- TODO: make these setting variables
+	local eligibleGatewayReward =
+		math.floor(totalEligibleRewards * constants.gatewayOperatorRewardRatio / #activeGatewayAddresses)
+	local eligibleObserverReward = math.floor(
+		totalEligibleRewards * constants.observerRewardRatio / utils.lengthOfTable(prescribedObserversLookup)
+	)
 	-- compute for each gateway what their potential rewards are and for their delegates
 	local potentialRewards = {}
 	-- use ipairs as activeGatewayAddresses is an array

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -339,9 +339,10 @@ end
 --- @param timestamp number The timestamp
 --- @return number # 	The epoch index
 function epochs.getEpochIndexForTimestamp(timestamp)
+	local timestampInMS = utils.checkAndConvertTimestampToMs(timestamp)
 	local epochZeroStartTimestamp = epochs.getSettings().epochZeroStartTimestamp
 	local epochLengthMs = epochs.getSettings().durationMs
-	local epochIndex = math.floor((timestamp - epochZeroStartTimestamp) / epochLengthMs)
+	local epochIndex = math.floor((timestampInMS - epochZeroStartTimestamp) / epochLengthMs)
 	return epochIndex
 end
 

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -1599,7 +1599,6 @@ function planMinimumStakesDrawdown(fundingPlan, stakingProfile)
 	end
 end
 
--- TODO: return event-worthy data
 --- Reduces all balances and creates withdraw stakes as prescribed by the funding plan
 --- @param fundingPlan table The funding plan to apply
 --- @param msgId string The current message ID

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -723,8 +723,6 @@ function gar.getGatewayWeightsAtTimestamp(gatewayAddresses, timestamp)
 			-- the percentage of the epoch the gateway was joined for before this epoch, if the gateway starts in the future this will be 0
 			local gatewayStartTimestamp = gateway.startTimestamp
 			local totalTimeForGateway = timestamp >= gatewayStartTimestamp and (timestamp - gatewayStartTimestamp) or -1
-			-- TODO: should we increment by one here or are observers that join at the epoch start not eligible to be selected as an observer
-
 			local calculatedTenureWeightForGateway = totalTimeForGateway < 0 and 0
 				or (
 					totalTimeForGateway > 0 and totalTimeForGateway / gar.getSettings().observers.tenureWeightPeriod
@@ -1066,7 +1064,6 @@ function gar.slashOperatorStake(address, slashAmount, currentTimestamp)
 	gateway.slashings[tostring(currentTimestamp)] = slashAmount
 	balances.increaseBalance(ao.id, slashAmount)
 	GatewayRegistry[address] = gateway
-	-- TODO: send slash notice to gateway address
 end
 
 ---@param cursor string|nil # The cursor gateway address after which to fetch more gateways (optional)

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -27,7 +27,7 @@ local gar = {}
 --- @field services GatewayServices | nil
 --- @field status "joined"|"leaving"
 --- @field observerAddress WalletAddress
---- @field weights GatewayWeights | nil // TODO: make this required and update tests to match the type
+--- @field weights GatewayWeights
 --- @field slashings table<Timestamp, mARIO> | nil
 
 --- @class Gateway : CompactGateway
@@ -1724,7 +1724,7 @@ end
 
 --- Fetch a heterogenous array of all active and vaulted delegated stakes, cursored on startTimestamp
 --- @param address string The address of the delegator
---- @param cursor string|nil The cursor after which to fetch more stakes (optional)
+--- @param cursor string|number|nil The cursor after which to fetch more stakes (optional)
 --- @param limit number The max number of stakes to fetch
 --- @param sortBy string The field to sort by. Default is "startTimestamp"
 --- @param sortOrder string The order to sort by, either "asc" or "desc". Default is "asc"

--- a/src/main.lua
+++ b/src/main.lua
@@ -89,8 +89,8 @@ local ActionMap = {
 	--- ArNS
 	Record = "Record",
 	Records = "Records",
-	BuyRecord = "Buy-Record", -- TODO: standardize these as `Buy-Name`
-	BuyName = "Buy-Name", -- TODO: standardize these as `Buy-Name`
+	BuyRecord = "Buy-Record", -- deprecated - use Buy-Name instead
+	BuyName = "Buy-Name",
 	UpgradeName = "Upgrade-Name",
 	ExtendLease = "Extend-Lease",
 	IncreaseUndernameLimit = "Increase-Undername-Limit",
@@ -99,8 +99,10 @@ local ActionMap = {
 	ReservedNames = "Reserved-Names",
 	ReservedName = "Reserved-Name",
 	TokenCost = "Token-Cost",
-	CostDetails = "Get-Cost-Details-For-Action",
-	GetRegistrationFees = "Get-Registration-Fees",
+	GetCostDetails = "Get-Cost-Details-For-Action", -- deprecated - use Cost-Details instead
+	CostDetails = "Cost-Details",
+	GetRegistrationFees = "Get-Registration-Fees", -- deprecated - use Registration-Fees instead
+	RegistrationFees = "Registration-Fees",
 	ReturnedNames = "Returned-Names",
 	ReturnedName = "Returned-Name",
 	AllowDelegates = "Allow-Delegates",
@@ -781,7 +783,9 @@ addEventingHandler(ActionMap.IncreaseVault, utils.hasMatchingTag("Action", Actio
 	})
 end)
 
-local function buyName(msg)
+addEventingHandler(ActionMap.BuyRecord, function(msg)
+	return msg.Action == ActionMap.BuyRecord or msg.Action == ActionMap.BuyName
+end, function(msg)
 	local name = msg.Tags.Name and string.lower(msg.Tags.Name) or nil
 	local purchaseType = msg.Tags["Purchase-Type"] and string.lower(msg.Tags["Purchase-Type"]) or "lease"
 	local years = msg.Tags.Years or nil
@@ -852,10 +856,7 @@ local function buyName(msg)
 			}),
 		})
 	end
-end
-
-addEventingHandler(ActionMap.BuyRecord, utils.hasMatchingTag("Action", ActionMap.BuyRecord), buyName)
-addEventingHandler("buyName", utils.hasMatchingTag("Action", ActionMap.BuyName), buyName)
+end)
 
 addEventingHandler("upgradeName", utils.hasMatchingTag("Action", ActionMap.UpgradeName), function(msg)
 	local fundFrom = msg.Tags["Fund-From"]
@@ -1002,7 +1003,9 @@ addEventingHandler(ActionMap.TokenCost, utils.hasMatchingTag("Action", ActionMap
 	})
 end)
 
-addEventingHandler(ActionMap.CostDetails, utils.hasMatchingTag("Action", ActionMap.CostDetails), function(msg)
+addEventingHandler(ActionMap.GetCostDetails, function(msg)
+	return msg.Action == ActionMap.CostDetails or msg.Action == ActionMap.GetCostDetails
+end, function(msg)
 	local fundFrom = msg.Tags["Fund-From"]
 	local name = string.lower(msg.Tags.Name)
 	local years = msg.Tags.Years or 1
@@ -1032,19 +1035,17 @@ addEventingHandler(ActionMap.CostDetails, utils.hasMatchingTag("Action", ActionM
 	})
 end)
 
-addEventingHandler(
-	ActionMap.GetRegistrationFees,
-	utils.hasMatchingTag("Action", ActionMap.GetRegistrationFees),
-	function(msg)
-		local priceList = arns.getRegistrationFees()
+addEventingHandler(ActionMap.GetRegistrationFees, function(msg)
+	return msg.Action == ActionMap.RegistrationFees or msg.Action == ActionMap.GetRegistrationFees
+end, function(msg)
+	local priceList = arns.getRegistrationFees()
 
-		Send(msg, {
-			Target = msg.From,
-			Tags = { Action = ActionMap.GetRegistrationFees .. "-Notice" },
-			Data = json.encode(priceList),
-		})
-	end
-)
+	Send(msg, {
+		Target = msg.From,
+		Tags = { Action = ActionMap.GetRegistrationFees .. "-Notice" },
+		Data = json.encode(priceList),
+	})
+end)
 
 addEventingHandler(ActionMap.JoinNetwork, utils.hasMatchingTag("Action", ActionMap.JoinNetwork), function(msg)
 	local updatedSettings = {

--- a/src/main.lua
+++ b/src/main.lua
@@ -228,11 +228,8 @@ end
 
 local function addReturnedNameResultFields(ioEvent, result)
 	ioEvent:addFieldsIfExist(result, {
-		"bidAmount",
 		"rewardForInitiator",
 		"rewardForProtocol",
-		"startPrice",
-		"floorPrice",
 		"type",
 		"years",
 	})

--- a/src/primary_names.lua
+++ b/src/primary_names.lua
@@ -2,10 +2,8 @@ local arns = require("arns")
 local balances = require("balances")
 local utils = require("utils")
 local gar = require("gar")
+local constants = require("constants")
 local primaryNames = {}
-
--- TODO: Figure out how to modulate this according to market conditions since it's actual spending
-local ONE_WEEK_IN_MS = 604800000
 
 --- @alias WalletAddress string
 --- @alias ArNSName string
@@ -101,7 +99,7 @@ function primaryNames.createPrimaryNameRequest(name, initiator, timestamp, msgId
 	local request = {
 		name = name,
 		startTimestamp = timestamp,
-		endTimestamp = timestamp + ONE_WEEK_IN_MS,
+		endTimestamp = timestamp + constants.oneWeekMs,
 	}
 
 	--- if the initiator is base name owner, then just set the primary name and return

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -514,34 +514,6 @@ function utils.splitAndTrimString(input, delimiter)
 	return tokens
 end
 
---- Checks if a timestamp is an integer and converts it to milliseconds if it is in seconds
---- @param timestamp number The timestamp to check and convert
---- @return number timestampInMs - the timestamp in milliseconds
-function utils.checkAndConvertTimestampToMs(timestamp)
-	-- Check if the timestamp is an integer
-	assert(type(timestamp) == "number", "Timestamp must be a number")
-	assert(utils.isInteger(timestamp), "Timestamp must be an integer")
-
-	-- Define the plausible range for Unix timestamps in seconds
-	local min_timestamp = 0
-	local max_timestamp = 4102444800 -- Corresponds to 2100-01-01
-
-	if timestamp >= min_timestamp and timestamp <= max_timestamp then
-		-- The timestamp is already in seconds, convert it to milliseconds
-		return timestamp * 1000
-	end
-
-	-- If the timestamp is outside the range for seconds, check for milliseconds
-	local min_timestamp_ms = min_timestamp * 1000
-	local max_timestamp_ms = max_timestamp * 1000
-
-	if timestamp >= min_timestamp_ms and timestamp <= max_timestamp_ms then
-		return timestamp
-	end
-
-	error("Timestamp is out of range")
-end
-
 function utils.reduce(tbl, fn, init)
 	local acc = init
 	local i = 1

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -514,6 +514,34 @@ function utils.splitAndTrimString(input, delimiter)
 	return tokens
 end
 
+--- Checks if a timestamp is an integer and converts it to milliseconds if it is in seconds
+--- @param timestamp number The timestamp to check and convert
+--- @return number timestampInMs - the timestamp in milliseconds
+function utils.checkAndConvertTimestampToMs(timestamp)
+	-- Check if the timestamp is an integer
+	assert(type(timestamp) == "number", "Timestamp must be a number")
+	assert(utils.isInteger(timestamp), "Timestamp must be an integer")
+
+	-- Define the plausible range for Unix timestamps in seconds
+	local min_timestamp = 0
+	local max_timestamp = 4102444800 -- Corresponds to 2100-01-01
+
+	if timestamp >= min_timestamp and timestamp <= max_timestamp then
+		-- The timestamp is already in seconds, convert it to milliseconds
+		return timestamp * 1000
+	end
+
+	-- If the timestamp is outside the range for seconds, check for milliseconds
+	local min_timestamp_ms = min_timestamp * 1000
+	local max_timestamp_ms = max_timestamp * 1000
+
+	if timestamp >= min_timestamp_ms and timestamp <= max_timestamp_ms then
+		return timestamp
+	end
+
+	error("Timestamp is out of range")
+end
+
 function utils.reduce(tbl, fn, init)
 	local acc = init
 	local i = 1

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -332,7 +332,7 @@ function utils.formatAddress(address)
 end
 
 --- Safely decodes a JSON string
---- @param jsonString string The JSON string to decode
+--- @param jsonString string|nil The JSON string to decode
 --- @return table|nil decodedJson - the decoded JSON or nil if the string is nil or the decoding fails
 function utils.safeDecodeJson(jsonString)
 	if not jsonString then
@@ -500,10 +500,14 @@ function utils.trimString(input)
 end
 
 --- Splits a string by a delimiter and trims each token
---- @param input string The string to split
---- @param delimiter string The delimiter to split by
+--- @param input string|nil The string to split
+--- @param delimiter string|nil The delimiter to split by, defaults to ","
 --- @return table tokens - the split and trimmed string
 function utils.splitAndTrimString(input, delimiter)
+	delimiter = escapePattern(delimiter or ",")
+	if not input then
+		return {}
+	end
 	local tokens = {}
 	for _, token in ipairs(utils.splitString(input, delimiter)) do
 		local trimmed = utils.trimString(token)

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -24,7 +24,7 @@ describe('handlers', async () => {
     const defaultIndex = handlersList.indexOf('_default');
     const sanitizeIndex = handlersList.indexOf('sanitize');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 72; // TODO: update this if more handlers are added
+    const expectedHandlerCount = 73; // TODO: update this if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
     assert.ok(sanitizeIndex === 2);

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -24,7 +24,7 @@ describe('handlers', async () => {
     const defaultIndex = handlersList.indexOf('_default');
     const sanitizeIndex = handlersList.indexOf('sanitize');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 73; // TODO: update this if more handlers are added
+    const expectedHandlerCount = 72; // this should be updated if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
     assert.ok(sanitizeIndex === 2);

--- a/tests/monitor/monitor.test.mjs
+++ b/tests/monitor/monitor.test.mjs
@@ -119,7 +119,7 @@ describe('setup', () => {
         'No eligible rewards found for current epoch',
       );
 
-      // TODO: for now pass if distributions are empty
+      // No eligible rewards for the current epoch
       if (
         Object.keys(currentEpochDistributions.rewards.eligible).length === 0
       ) {
@@ -180,7 +180,6 @@ describe('setup', () => {
         `Delegated supply is undefined: ${supplyData.delegated}`,
       );
 
-      // TODO: there is an unknown precision loss on these values, we are discussing why with Forward. Once fixed, uncomment these tests
       const { items: balances } = await io.getBalances({
         limit: 10_000,
       });
@@ -543,19 +542,16 @@ describe('setup', () => {
   describe('arns names', () => {
     const twoWeeks = 2 * 7 * 24 * 60 * 60 * 1000;
     it('should not have any arns records older than two weeks', async () => {
-      // TODO: Remove this when we figure out whether do/while is causing test hanging
-      const timeoutPromise = new Promise((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Test timed out after 60 seconds')),
-          60000,
-        ),
-      );
+      const signal = new AbortSignal().timeout(60000);
 
       const testLogicPromise = (async () => {
         let cursor = undefined;
         let totalArns = 0;
         const uniqueNames = new Set();
         do {
+          if (signal.aborted) {
+            throw new Error('Test timed out after 60 seconds');
+          }
           const {
             items: arns,
             nextCursor,

--- a/tests/monitor/monitor.test.mjs
+++ b/tests/monitor/monitor.test.mjs
@@ -364,7 +364,7 @@ describe('setup', () => {
 
   // gateway registry - ensure no invalid gateways
   describe('gateway registry', () => {
-    it('should only have valid gateways', async () => {
+    it.timeout(60000, 'should only have valid gateways', async () => {
       const { durationMs, epochZeroStartTimestamp } =
         await io.getEpochSettings();
       // compute the epoch index based on the epoch settings

--- a/tests/primary.test.mjs
+++ b/tests/primary.test.mjs
@@ -140,6 +140,7 @@ describe('primary names', function () {
     caller,
     memory,
     timestamp = STUB_TIMESTAMP,
+    notifyOwners = false,
   }) => {
     const removePrimaryNamesResult = await handle({
       options: {
@@ -149,6 +150,7 @@ describe('primary names', function () {
         Tags: [
           { name: 'Action', value: 'Remove-Primary-Names' },
           { name: 'Names', value: names.join(',') },
+          { name: 'Notify-Owners', value: notifyOwners ? 'true' : 'false' },
         ],
       },
       memory,
@@ -508,6 +510,7 @@ describe('primary names', function () {
       caller: processId,
       memory: approvePrimaryNameRequestResult.Memory,
       timestamp: requestTimestamp,
+      notifyOwners: true, // notify the owner of the primary name
     });
 
     // assert no error
@@ -553,6 +556,7 @@ describe('primary names', function () {
       Timestamp: requestTimestamp,
       'Total-Primary-Name-Requests': 0,
       'Total-Primary-Names': 0,
+      'Notify-Owners': 'true',
     });
     // assert the primary name is no longer set
     const { result: primaryNameForAddressResult, memory } =


### PR DESCRIPTION
this PR addresses some of the TODOs. We still have 23 in the codebase, quite a few around improved testing coverage


- ~~removes timestamp conversion (looks good so far, test this devnet)~~ <-- did not blend, we need this converison
- gives types for ARIOEvent
- Adds Buy-Name handler in addition to Buy-Record in preparation for standardizing on `Name`
- excises TODOs that are already done or seemed unnecessary 

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/c8351920-a408-4cdf-abed-b11a4eea1067" />

