### PR TITLE
chore(validation): `LastKnownMessageTimestamp` is giving issues for e…

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -387,7 +387,8 @@ end
 -- Sanitize inputs before every interaction
 local function assertAndSanitizeInputs(msg)
 	assert(
-		msg.Timestamp and tonumber(msg.Timestamp) >= LastKnownMessageTimestamp,
+		-- TODO: replace this with LastKnownMessageTimestamp after node release 23.0.0
+		msg.Timestamp and tonumber(msg.Timestamp) >= 0,
 		"Timestamp must be greater than or equal to the last known message timestamp of "
 			.. LastKnownMessageTimestamp
 			.. " but was "


### PR DESCRIPTION
…xisting observers. For now we will allow anything greater than 0 until release 23, where they will use the latest SDK.