### PR TITLE
PE-7351: correctly account for moving stakes during redelegation 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,5 +37,11 @@
     "editor.formatOnPaste": true,
     "editor.formatOnSaveMode": "file"
   },
-  "cSpell.words": ["ARIO", "hashchain", "redelegate"]
+  "cSpell.words": [
+    "ARIO",
+    "hashchain",
+    "redelegate",
+    "redelegation",
+    "redelegations"
+  ]
 }

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -1777,10 +1777,10 @@ end
 --- @field vaultId string | nil # The vault id to redelegate from (optional)
 
 --- @class RedelegateStakeResult
---- @field sourceGateway table # The updated gateway object that the stake was moved from
---- @field targetGateway table # The updated gateway object that the stake was moved to
+--- @field sourceAddress WalletAddress # The address of the gateway that the stake was moved from
+--- @field targetAddress table # The address of the gateway that the stake was moved to
 --- @field redelegationFee number # The fee charged for the redelegation
---- @field feeResetTimestamp number # The timestamp when the reldelegation fee will be reset
+--- @field feeResetTimestamp number # The timestamp when the redelegation fee will be reset
 --- @field redelegationsSinceFeeReset number # The number of redelegations the user has made since the last fee reset
 
 --- Take stake from a delegate and stake it to a new delegate.

--- a/src/main.lua
+++ b/src/main.lua
@@ -2270,24 +2270,29 @@ addEventingHandler(ActionMap.RedelegateStake, utils.hasMatchingTag("Action", Act
 	local isStakeMovingFromDelegateToOperator = delegateAddress == targetAddress
 	local isStakeMovingFromOperatorToDelegate = delegateAddress == sourceAddress
 	local isStakeMovingFromWithdrawal = vaultId ~= nil
+	if isStakeMovingFromWithdrawal then
+		LastKnownWithdrawSupply = LastKnownWithdrawSupply - quantity
+	end
 
 	if isStakeMovingFromDelegateToOperator then
-		if isStakeMovingFromWithdrawal then
-			LastKnownWithdrawSupply = LastKnownWithdrawSupply - stakeMoved
-		else
-			LastKnownDelegatedSupply = LastKnownDelegatedSupply - stakeMoved
+		if not isStakeMovingFromWithdrawal then
+			LastKnownDelegatedSupply = LastKnownDelegatedSupply - quantity
 		end
 		LastKnownStakedSupply = LastKnownStakedSupply + stakeMoved
 	elseif isStakeMovingFromOperatorToDelegate then
-		if isStakeMovingFromWithdrawal then
-			LastKnownWithdrawSupply = LastKnownWithdrawSupply + stakeMoved
-		else
-			LastKnownStakedSupply = LastKnownStakedSupply - stakeMoved
+		if not isStakeMovingFromWithdrawal then
+			LastKnownStakedSupply = LastKnownStakedSupply - quantity
 		end
 		LastKnownDelegatedSupply = LastKnownDelegatedSupply + stakeMoved
+	elseif isStakeMovingFromWithdrawal then
+		LastKnownStakedSupply = LastKnownStakedSupply + stakeMoved
+		-- else
+		-- Stake is simply moving from one delegation to another
 	end
 
-	LastKnownCirculatingSupply = LastKnownCirculatingSupply - redelegationResult.redelegationFee
+	if redelegationFee > 0 then
+		msg.ioEvent:addField("Redelegation-Fee", redelegationFee)
+	end
 	addSupplyData(msg.ioEvent)
 
 	Send(msg, {

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -1597,6 +1597,7 @@ describe('GatewayRegistry', async () => {
         },
         memory,
       });
+      assertNoResultError(result);
       return {
         result,
         memory: result.Memory,
@@ -1625,13 +1626,15 @@ describe('GatewayRegistry', async () => {
         memory: joinTargetMemory,
       });
 
-      const { memory: delegatedStakeMemory } = await delegateStake({
-        delegatorAddress,
-        quantity: stakeQty,
-        gatewayAddress: sourceAddress,
-        timestamp: STUB_TIMESTAMP,
-        memory: transferMemory,
-      });
+      const { result: delegateStakeResult, memory: delegatedStakeMemory } =
+        await delegateStake({
+          delegatorAddress,
+          quantity: stakeQty,
+          gatewayAddress: sourceAddress,
+          timestamp: STUB_TIMESTAMP,
+          memory: transferMemory,
+        });
+      assertNoResultError(delegateStakeResult);
 
       const sourceGatewayBefore = await getGateway({
         address: sourceAddress,
@@ -1780,14 +1783,16 @@ describe('GatewayRegistry', async () => {
       );
 
       const decreaseStakeMsgId = 'decrease-stake-message-id-'.padEnd(43, 'x');
-      const { memory: decreaseStakeMemory } = await decreaseDelegateStake({
-        memory: delegatedStakeMemory,
-        timestamp: STUB_TIMESTAMP + 1,
-        delegatorAddress,
-        decreaseQty: stakeQty,
-        gatewayAddress: sourceAddress,
-        messageId: decreaseStakeMsgId,
-      });
+      const { result: decreaseStakeResult, memory: decreaseStakeMemory } =
+        await decreaseDelegateStake({
+          memory: delegatedStakeMemory,
+          timestamp: STUB_TIMESTAMP + 1,
+          delegatorAddress,
+          decreaseQty: stakeQty,
+          gatewayAddress: sourceAddress,
+          messageId: decreaseStakeMsgId,
+        });
+      assertNoResultError(decreaseStakeResult);
 
       const { memory: redelegateStakeMemory } = await redelegateStake({
         memory: decreaseStakeMemory,


### PR DESCRIPTION
Issues found:
- LastKnownWithdrawSupply being ADDED to rather than subtracted from
- LastKnownStakedSupply not being added to in the case where a delegation withdraw vault is used to redelegate to a new gateway
- (minor) incorrect types returned from gar.redelegateStake
