### PR TITLE
fix(balances): return balance as string 

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -1830,7 +1830,7 @@ addEventingHandler(ActionMap.Balance, Handlers.utils.hasMatchingTag("Action", Ac
 	local target = msg.Tags.Target or msg.Tags.Address or msg.Tags.Recipient or msg.From
 	local balance = balances.getBalance(target)
 
-	-- must adhere to token.lua spec for arconnect compatibility
+	-- must adhere to token.lua spec defined by https://github.com/permaweb/aos/blob/15dd81ee596518e2f44521e973b8ad1ce3ee9945/blueprints/token.lua
 	Send(msg, {
 		Target = msg.From,
 		Action = "Balance-Notice",

--- a/src/main.lua
+++ b/src/main.lua
@@ -1835,7 +1835,7 @@ addEventingHandler(ActionMap.Balance, Handlers.utils.hasMatchingTag("Action", Ac
 		Target = msg.From,
 		Action = "Balance-Notice",
 		Account = target,
-		Data = balance,
+		Data = tostring(balance),
 		Balance = tostring(balance),
 		Ticker = Ticker,
 	})

--- a/tests/balances.test.mjs
+++ b/tests/balances.test.mjs
@@ -1,0 +1,27 @@
+import { getBalance, getBalances, startMemory } from './helpers.mjs';
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { STUB_ADDRESS, PROCESS_OWNER } from '../tools/constants.mjs';
+
+describe('Balances', async () => {
+  it('should return the balance for a specific address', async () => {
+    const balance = await getBalance({
+      address: PROCESS_OWNER,
+      memory: startMemory,
+    });
+    assert.equal(balance, 950000000000000);
+  });
+
+  it('should return 0 for a non-existent address', async () => {
+    const balance = await getBalance({
+      address: STUB_ADDRESS,
+      memory: startMemory,
+    });
+    assert.equal(balance, 0);
+  });
+
+  it('should return dictionary of all balances', async () => {
+    const balances = await getBalances({ memory: startMemory });
+    assert.equal(balances[PROCESS_OWNER], 950000000000000);
+  });
+});

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -135,13 +135,14 @@ export const getBalance = async ({
   });
   // enforce the token.lua "spec" as defined by https://github.com/permaweb/aos/blob/15dd81ee596518e2f44521e973b8ad1ce3ee9945/blueprints/token.lua
   assert(
-    result.Messages[0].Tags.every(
-      (tag) => tag.name in ['Action', 'Address', 'Balance'],
+    ['Action', 'Balance', 'Account', 'Ticker'].every((tag) =>
+      result.Messages[0].Tags.map((t) => t.name).includes(tag),
     ),
-    'Tags are not in compliance with the token.lua spec.',
+    `Tags are not in compliance with the token.lua spec. ${JSON.stringify(result.Messages[0].Tags, null, 2)}`,
   );
   assert(
-    typeof result.Messages[0].Data === 'string',
+    typeof result.Messages[0].Data === 'string' &&
+      !isNaN(Number(result.Messages[0].Data)),
     'Balance is invalid. It is not a string which is out of compliance with the token.lua spec',
   );
   const balance = JSON.parse(result.Messages[0].Data);

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -123,8 +123,18 @@ export const getBalance = async ({
   memory,
   timestamp = STUB_TIMESTAMP,
 }) => {
-  const balances = await getBalances({ memory, timestamp });
-  return balances[address];
+  const result = await handle({
+    options: {
+      Tags: [
+        { name: 'Action', value: 'Balance' },
+        { name: 'Address', value: address },
+      ],
+    },
+    timestamp,
+    memory,
+  });
+  const balance = JSON.parse(result.Messages[0].Data);
+  return balance;
 };
 
 export const transfer = async ({

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -133,6 +133,17 @@ export const getBalance = async ({
     timestamp,
     memory,
   });
+  // enforce the token.lua "spec" as defined by https://github.com/permaweb/aos/blob/15dd81ee596518e2f44521e973b8ad1ce3ee9945/blueprints/token.lua
+  assert(
+    result.Messages[0].Tags.every(
+      (tag) => tag.name in ['Action', 'Address', 'Balance'],
+    ),
+    'Tags are not in compliance with the token.lua spec.',
+  );
+  assert(
+    typeof result.Messages[0].Data === 'string',
+    'Balance is invalid. It is not a string which is out of compliance with the token.lua spec',
+  );
   const balance = JSON.parse(result.Messages[0].Data);
   return balance;
 };

--- a/tests/monitor/monitor.test.mjs
+++ b/tests/monitor/monitor.test.mjs
@@ -95,6 +95,17 @@ describe('setup', () => {
         );
       }
     });
+
+    it('should always be able to fetch the protocol balance and it should be greater than 0', async () => {
+      const balance = await io.getBalance({
+        address: processId,
+      });
+      // assert it is greater than 0 and response is a number
+      assert(
+        balance >= 0 && typeof balance === 'number',
+        'Balance is not valid',
+      );
+    });
   });
 
   describe('distribution totals', () => {


### PR DESCRIPTION
For unknown reasons, the MU does not crank the `Balance-Notice` message back to a calling process when `Data` is not a string. This updates all handlers that return numbers to return the strings.

My initial thought was that this would cause breaking changes with the SDK - but given our use of `JSON.parse` - which parses strings to numbers, it actually has no obvious downstream consequences. We will continue to test in devnet before pushing to testnet, specifically with arns.app, network-portal.app and ArConnect.

Related: https://github.com/ar-io/ar-io-sdk/pull/327