### PR TITLE
PE-7281: collect more information in tallying workloads

### DIFF
--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -2009,6 +2009,16 @@ describe("gar", function()
 					gatewayStakeReturned = 0,
 					delegateStakeWithdrawing = 0,
 					gatewayStakeWithdrawing = 8000010000,
+					gatewayObjectTallies = {
+						numDelegateVaults = 0,
+						numDelegatesVaulting = 0,
+						numDelegations = 0,
+						numExitingDelegations = 0,
+						numExitingGateways = 1,
+						numGatewayVaults = 0,
+						numGateways = 1,
+						numGatewaysVaulting = 0,
+					},
 				}, result)
 
 				local expectedRemainingStake = math.floor(minOperatorStake * 0.8) + 10000

--- a/src/ao_event.lua
+++ b/src/ao_event.lua
@@ -6,7 +6,7 @@ local json = require("json")
 --- @field sampleRate number|nil Optional sample rate.
 --- @field addField fun(self: AOEvent, key: string, value: any): AOEvent Adds a single field to the event.
 --- @field addFields fun(self: AOEvent, fields: table<string, any>): AOEvent Adds multiple fields to the event.
---- @field addFieldsIfExist fun(self: AOEvent, table: table<string, any>, fields: table<string>): AOEvent Adds specific fields if they exist in the given table.
+--- @field addFieldsIfExist fun(self: AOEvent, table: table<string, any>|nil, fields: table<string>): AOEvent Adds specific fields if they exist in the given table.
 --- @field addFieldsWithPrefixIfExist fun(self: AOEvent, srcTable: table<string, any>, prefix: string, fields: table<string>): AOEvent
 ---  Adds fields with a prefix if they exist in the source table.
 --- @field printEvent fun(self: AOEvent): nil Prints the event in JSON format.

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -787,7 +787,7 @@ function gar.assertValidGatewayParameters(from, stake, settings, services, obser
 		assert(type(settings.allowDelegatedStaking) == "boolean", "allowDelegatedStaking must be a boolean")
 	end
 	if type(settings.allowedDelegates) == "table" then
-		for _, delegate in ipairs(settings.allowedDelegates) do
+		for _, delegate in pairs(settings.allowedDelegates) do
 			assert(utils.isValidAddress(delegate, true), "delegates in allowedDelegates must be valid AO addresses")
 		end
 	else
@@ -934,7 +934,7 @@ function gar.addGateway(address, gateway)
 	return gateway
 end
 
---- @class PrunedGatewaysResult
+--- @class PruneGatewaysResult
 --- @field prunedGateways Gateway[] The pruned gateways
 --- @field slashedGateways table<WalletAddress, number> The slashed gateways and their amounts
 --- @field gatewayStakeReturned number The gateway stake returned
@@ -942,12 +942,14 @@ end
 --- @field gatewayStakeWithdrawing number The gateway stake withdrawing
 --- @field delegateStakeWithdrawing number The delegate stake withdrawing
 --- @field stakeSlashed number The stake slashed
+--- @field gatewayObjectTallies GatewayObjectTallies|nil Statistics on the gateway system
 
 --- Prunes gateways that have failed more than 30 consecutive epochs
 --- @param currentTimestamp number The current timestamp
 --- @param msgId string The message ID
---- @return PrunedGatewaysResult # The result containing the pruned gateways, slashed gateways, and other stats
+--- @return PruneGatewaysResult # The result containing the pruned gateways, slashed gateways, and other stats
 function gar.pruneGateways(currentTimestamp, msgId)
+	--- @type PruneGatewaysResult
 	local result = {
 		prunedGateways = {},
 		slashedGateways = {},
@@ -961,6 +963,18 @@ function gar.pruneGateways(currentTimestamp, msgId)
 		-- No known pruning work to do
 		return result
 	end
+
+	--- @type GatewayObjectTallies
+	local gatewayObjectTallies = {
+		numDelegations = 0,
+		numExitingDelegations = 0,
+		numDelegateVaults = 0,
+		numDelegatesVaulting = 0,
+		numGatewayVaults = 0,
+		numGatewaysVaulting = 0,
+		numGateways = 0,
+		numExitingGateways = 0,
+	}
 
 	-- we take a deep copy so we can operate directly on the gateway objects
 	local gateways = gar.getGateways()
@@ -976,6 +990,7 @@ function gar.pruneGateways(currentTimestamp, msgId)
 	local minNextEndTimestamp
 	for address, gateway in pairs(gateways) do
 		if gateway then
+			gatewayObjectTallies.numGateways = gatewayObjectTallies.numGateways + 1
 			-- first, return any expired vaults regardless of the gateway status
 			for vaultId, vault in pairs(gateway.vaults) do
 				if vault.endTimestamp <= currentTimestamp then
@@ -985,7 +1000,11 @@ function gar.pruneGateways(currentTimestamp, msgId)
 				else
 					-- find the next prune timestamp
 					minNextEndTimestamp = math.min(minNextEndTimestamp or vault.endTimestamp, vault.endTimestamp)
+					gatewayObjectTallies.numGatewayVaults = gatewayObjectTallies.numGatewayVaults + 1
 				end
+			end
+			if next(gateway.vaults) ~= nil then
+				gatewayObjectTallies.numGatewaysVaulting = gatewayObjectTallies.numGatewaysVaulting + 1
 			end
 			-- return any delegated vaults and return the stake to the delegate
 			for delegateAddress, delegate in pairs(gateway.delegates) do
@@ -996,16 +1015,24 @@ function gar.pruneGateways(currentTimestamp, msgId)
 					else
 						-- find the next prune timestamp
 						minNextEndTimestamp = math.min(minNextEndTimestamp or vault.endTimestamp, vault.endTimestamp)
+						gatewayObjectTallies.numDelegateVaults = gatewayObjectTallies.numDelegateVaults + 1
 					end
 				end
-			end
-			-- remove the delegate if all vaults are empty and the delegated stake is 0
-			for delegateAddress, delegate in pairs(gateway.delegates) do
+				if next(delegate.vaults) ~= nil then
+					gatewayObjectTallies.numDelegatesVaulting = gatewayObjectTallies.numDelegatesVaulting + 1
+				end
+
+				-- remove the delegate if all vaults are empty and the delegated stake is 0
 				if delegate.delegatedStake == 0 and next(delegate.vaults) == nil then
 					-- any allowlist reassignment would have already taken place by now
 					gateway.delegates[delegateAddress] = nil
+				elseif delegate.delegatedStake > 0 then
+					gatewayObjectTallies.numDelegations = gatewayObjectTallies.numDelegations + 1
+				else
+					gatewayObjectTallies.numExitingDelegations = gatewayObjectTallies.numExitingDelegations + 1
 				end
 			end
+
 			-- update the gateway before we do anything else
 			GatewayRegistry[address] = gateway
 
@@ -1024,17 +1051,24 @@ function gar.pruneGateways(currentTimestamp, msgId)
 				gar.leaveNetwork(address, currentTimestamp, msgId)
 				result.slashedGateways[address] = slashAmount
 				result.stakeSlashed = result.stakeSlashed + slashAmount
+				gatewayObjectTallies.numGateways = gatewayObjectTallies.numGateways - 1
+				gatewayObjectTallies.numExitingGateways = gatewayObjectTallies.numExitingGateways + 1
 			else
-				if gateway.status == "leaving" and gateway.endTimestamp ~= nil then
-					if gateway.endTimestamp <= currentTimestamp then
-						-- prune the gateway
-						GatewayRegistry[address] = nil
-						table.insert(result.prunedGateways, address)
-					else
-						-- find the next prune timestamp
-						minNextEndTimestamp =
-							--- @diagnostic disable-next-line: param-type-mismatch
-							math.min(minNextEndTimestamp or gateway.endTimestamp, gateway.endTimestamp)
+				if gateway.status == "leaving" then
+					gatewayObjectTallies.numGateways = gatewayObjectTallies.numGateways - 1
+					gatewayObjectTallies.numExitingGateways = gatewayObjectTallies.numExitingGateways + 1
+					if gateway.endTimestamp ~= nil then
+						if gateway.endTimestamp <= currentTimestamp then
+							gatewayObjectTallies.numExitingGateways = gatewayObjectTallies.numExitingGateways - 1
+							-- prune the gateway
+							GatewayRegistry[address] = nil
+							table.insert(result.prunedGateways, address)
+						else
+							-- find the next prune timestamp
+							minNextEndTimestamp =
+								--- @diagnostic disable-next-line: param-type-mismatch
+								math.min(minNextEndTimestamp or gateway.endTimestamp, gateway.endTimestamp)
+						end
 					end
 				end
 			end
@@ -1046,6 +1080,8 @@ function gar.pruneGateways(currentTimestamp, msgId)
 	if minNextEndTimestamp then
 		gar.scheduleNextGatewaysPruning(minNextEndTimestamp)
 	end
+
+	result.gatewayObjectTallies = gatewayObjectTallies
 
 	return result
 end
@@ -1301,10 +1337,10 @@ function gar.isEligibleForArNSDiscount(from)
 end
 
 --- Remove delegate addresses from the allowedDelegatesLookup table in the gateway's settings
---- @param delegates table The list of delegate addresses to remove
---- @param gatewayAddress string The address of the gateway
---- @param msgId string The associated message ID
---- @param currentTimestamp number The current timestamp
+--- @param delegates WalletAddress[] The list of delegate addresses to remove
+--- @param gatewayAddress WalletAddress The address of the gateway
+--- @param msgId MessageId The associated message ID
+--- @param currentTimestamp Timestamp The current timestamp
 --- @return table result Result table containing updated gateway object and the delegates that were actually removed
 function gar.disallowDelegates(delegates, gatewayAddress, msgId, currentTimestamp)
 	local gateway = gar.getGateway(gatewayAddress)

--- a/src/tick.lua
+++ b/src/tick.lua
@@ -7,7 +7,7 @@ local gar = require("gar")
 --- @field maybeDistributedEpoch Epoch | nil The distributed epoch
 --- @field maybeNewEpoch Epoch | nil The new epoch
 --- @field maybeDemandFactor number | nil The demand factor
---- @field pruneGatewaysResult PrunedGatewaysResult The prune gateways result
+--- @field pruneGatewaysResult PruneGatewaysResult The prune gateways result
 
 --- Ticks an epoch. A tick is the process of updating the demand factor, distributing rewards, pruning gateways, and creating a new epoch.
 --- @param timestamp number The timestamp

--- a/src/token.lua
+++ b/src/token.lua
@@ -36,16 +36,6 @@ end
 --- @field numGateways number
 --- @field numExitingGateways number
 
---- @class GatewayObjectMaybeTallies
---- @field numDelegateVaults number|nil
---- @field numDelegatesVaulting number|nil
---- @field numDelegations number|nil
---- @field numExitingDelegations number|nil
---- @field numGatewayVaults number|nil
---- @field numGatewaysVaulting number|nil
---- @field numGateways number|nil
---- @field numExitingGateways number|nil
-
 --- @class StateObjectTallies : GatewayObjectTallies, BalanceObjectTallies
 
 --- @class TotalSupplyDetails

--- a/src/token.lua
+++ b/src/token.lua
@@ -21,17 +21,34 @@ function token.lastKnownTotalTokenSupply()
 		+ Balances[Protocol]
 end
 
---- @class StateObjectTallies
+--- @class BalanceObjectTallies
 --- @field numAddressesVaulting number
 --- @field numBalanceVaults number
 --- @field numBalances number
+
+--- @class GatewayObjectTallies
 --- @field numDelegateVaults number
+--- @field numDelegatesVaulting number
 --- @field numDelegations number
 --- @field numExitingDelegations number
 --- @field numGatewayVaults number
+--- @field numGatewaysVaulting number
 --- @field numGateways number
+--- @field numExitingGateways number
 
---- @class TotalSupplyDetails : StateObjectTallies
+--- @class GatewayObjectMaybeTallies
+--- @field numDelegateVaults number|nil
+--- @field numDelegatesVaulting number|nil
+--- @field numDelegations number|nil
+--- @field numExitingDelegations number|nil
+--- @field numGatewayVaults number|nil
+--- @field numGatewaysVaulting number|nil
+--- @field numGateways number|nil
+--- @field numExitingGateways number|nil
+
+--- @class StateObjectTallies : GatewayObjectTallies, BalanceObjectTallies
+
+--- @class TotalSupplyDetails
 --- @field totalSupply number
 --- @field circulatingSupply number
 --- @field lockedSupply number
@@ -39,6 +56,7 @@ end
 --- @field delegatedSupply number
 --- @field withdrawSupply number
 --- @field protocolBalance number
+--- @field stateObjectTallies StateObjectTallies
 
 --- Crawls the state to compute the total supply and update the last known values
 --- @return TotalSupplyDetails
@@ -52,58 +70,76 @@ function token.computeTotalSupply()
 	local withdrawSupply = 0
 	local protocolBalance = balances.getBalance(Protocol)
 	local userBalances = balances.getBalancesUnsafe()
-	local numBalances = 0
-	local numGateways = 0
-	local numGatewayVaults = 0
-	local numDelegations = 0
-	local numExitingDelegations = 0
-	local numDelegateVaults = 0
-	local numBalanceVaults = 0
-	local numAddressesVaulting = 0
+	--- @type StateObjectTallies
+	local stateObjectTallies = {
+		numAddressesVaulting = 0,
+		numBalanceVaults = 0,
+		numBalances = 0,
+		numDelegateVaults = 0,
+		numDelegatesVaulting = 0,
+		numDelegations = 0,
+		numExitingDelegations = 0,
+		numGatewayVaults = 0,
+		numGatewaysVaulting = 0,
+		numGateways = 0,
+		numExitingGateways = 0,
+	}
 
 	-- tally circulating supply
 	for _, balance in pairs(userBalances) do
 		circulatingSupply = circulatingSupply + balance
-		numBalances = numBalances + 1
+		stateObjectTallies.numBalances = stateObjectTallies.numBalances + 1
 	end
 	circulatingSupply = circulatingSupply - protocolBalance
 	totalSupply = totalSupply + protocolBalance + circulatingSupply
 
 	-- tally supply stashed in gateways and delegates
 	for _, gateway in pairs(gar.getGatewaysUnsafe()) do
-		numGateways = numGateways + 1
+		if gateway.status == "leaving" then
+			stateObjectTallies.numExitingGateways = stateObjectTallies.numExitingGateways + 1
+		else
+			stateObjectTallies.numGateways = stateObjectTallies.numGateways + 1
+		end
 		totalSupply = totalSupply + gateway.operatorStake + gateway.totalDelegatedStake
 		stakedSupply = stakedSupply + gateway.operatorStake
 		delegatedSupply = delegatedSupply + gateway.totalDelegatedStake
 		for _, delegate in pairs(gateway.delegates) do
 			if delegate.delegatedStake == 0 then
-				numExitingDelegations = numExitingDelegations + 1
+				stateObjectTallies.numExitingDelegations = stateObjectTallies.numExitingDelegations + 1
 			else
-				numDelegations = numDelegations + 1
+				stateObjectTallies.numDelegations = stateObjectTallies.numDelegations + 1
 			end
 
 			-- tally delegates' vaults
 			for _, vault in pairs(delegate.vaults) do
-				numDelegateVaults = numDelegateVaults + 1
+				stateObjectTallies.numDelegateVaults = stateObjectTallies.numDelegateVaults + 1
 				totalSupply = totalSupply + vault.balance
 				withdrawSupply = withdrawSupply + vault.balance
+			end
+			if next(delegate.vaults) then
+				stateObjectTallies.numDelegatesVaulting = stateObjectTallies.numDelegatesVaulting + 1
 			end
 		end
 		-- tally gateway's own vaults
 		for _, vault in pairs(gateway.vaults) do
-			numGatewayVaults = numGatewayVaults + 1
+			stateObjectTallies.numGatewayVaults = stateObjectTallies.numGatewayVaults + 1
 			totalSupply = totalSupply + vault.balance
 			withdrawSupply = withdrawSupply + vault.balance
+		end
+		if next(gateway.vaults) then
+			stateObjectTallies.numGatewaysVaulting = stateObjectTallies.numGatewaysVaulting + 1
 		end
 	end
 
 	-- user vaults
 	local userVaults = vaults.getVaultsUnsafe()
 	for _, vaultsForAddress in pairs(userVaults) do
-		numAddressesVaulting = numAddressesVaulting + 1
-		-- they may have several vaults iterate through them
+		if next(vaultsForAddress) ~= nil then
+			stateObjectTallies.numAddressesVaulting = stateObjectTallies.numAddressesVaulting + 1
+		end
+		-- they may have several vaults; iterate through them
 		for _, vault in pairs(vaultsForAddress) do
-			numBalanceVaults = numBalanceVaults + 1
+			stateObjectTallies.numBalanceVaults = stateObjectTallies.numBalanceVaults + 1
 			totalSupply = totalSupply + vault.balance
 			lockedSupply = lockedSupply + vault.balance
 		end
@@ -123,14 +159,7 @@ function token.computeTotalSupply()
 		delegatedSupply = delegatedSupply,
 		withdrawSupply = withdrawSupply,
 		protocolBalance = protocolBalance,
-		numAddressesVaulting = numAddressesVaulting,
-		numBalanceVaults = numBalanceVaults,
-		numBalances = numBalances,
-		numDelegateVaults = numDelegateVaults,
-		numDelegations = numDelegations,
-		numExitingDelegations = numExitingDelegations,
-		numGatewayVaults = numGatewayVaults,
-		numGateways = numGateways,
+		stateObjectTallies = stateObjectTallies,
 	}
 end
 


### PR DESCRIPTION
New tallying info:
- Number of delegates that have a vault (distinct from total number of delegate vaults)
- Number of gateways that have a vault (distinct from total number of gateway vaults)
- Number of gateways that are exiting (now no longer part of the count of total gateways)

Also now collecting tallying info during prune gateways since that is the routine place where gateways objects are fully iterated through.