### PR TITLE
feat: add all paginated delegates to main handlers PE-7221

### DIFF
--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -2102,7 +2102,6 @@ describe("gar", function()
 			}, result)
 			assert.are.equal(nil, _G.GatewayRegistry[stubGatewayAddress].vaults["some-previous-withdrawal-id"])
 		end)
-
 		it("should not cancel a gateway withdrawal if the gateway is leaving", function()
 			_G.GatewayRegistry[stubGatewayAddress] = testGateway
 			_G.GatewayRegistry[stubGatewayAddress].status = "leaving"
@@ -2116,7 +2115,6 @@ describe("gar", function()
 			assert.is_not_nil(err)
 			assert.matches("Gateway is leaving the network and cannot cancel withdrawals.", err)
 		end)
-
 		it("should not cancel a gateway withdrawal if the vault id is not found", function()
 			_G.GatewayRegistry[stubGatewayAddress] = testGateway
 			_G.GatewayRegistry[stubGatewayAddress].status = "joined"

--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -4677,9 +4677,15 @@ describe("gar", function()
 			function()
 				local gateway1 = utils.deepCopy(testGateway)
 				local gateway2 = utils.deepCopy(testGateway)
+				local anotherAddress = "0x123"
 				gateway1.delegates = {
 					[stubGatewayAddress] = {
 						delegatedStake = 100,
+						startTimestamp = 0,
+						vaults = {},
+					},
+					[anotherAddress] = {
+						delegatedStake = 300,
 						startTimestamp = 0,
 						vaults = {},
 					},
@@ -4696,43 +4702,72 @@ describe("gar", function()
 							},
 						},
 					},
+					[anotherAddress] = {
+						delegatedStake = 500,
+						startTimestamp = 0,
+						vaults = {
+							["vault-1"] = {
+								balance = 1000,
+								startTimestamp = 0,
+								endTimestamp = 1000,
+							},
+						},
+					},
 				}
 				_G.GatewayRegistry = {
 					[stubRandomAddress] = gateway1,
 					[stubGatewayAddress] = gateway2,
 				}
-				local delegates = gar.getPaginatedDelegatesFromAllGateways(nil, 1)
+				local delegates = gar.getPaginatedDelegatesFromAllGateways(nil, 2)
 
 				assert.are.same({
-					limit = 1,
+					limit = 2,
 					sortBy = "delegatedStake",
 					sortOrder = "desc",
 					hasMore = true,
-					nextCursor = stubRandomAddress,
-					totalItems = 2,
+					nextCursor = anotherAddress .. "_" .. stubRandomAddress,
+					totalItems = 4,
 					items = {
 						{
-							address = stubRandomAddress,
+							address = anotherAddress,
+							cursorKey = anotherAddress .. "_" .. stubGatewayAddress,
 							gatewayAddress = stubGatewayAddress,
-							delegatedStake = 200,
+							delegatedStake = 500,
 							startTimestamp = 0,
-							vaultedStake = 200,
+							vaultedStake = 1000,
+						},
+						{
+							address = anotherAddress,
+							cursorKey = anotherAddress .. "_" .. stubRandomAddress,
+							gatewayAddress = stubRandomAddress,
+							delegatedStake = 300,
+							startTimestamp = 0,
+							vaultedStake = 0,
 						},
 					},
 				}, delegates)
 
 				-- get the next page
-				local nextPage = gar.getPaginatedDelegatesFromAllGateways(tostring(delegates.nextCursor), 1)
+				local nextPage = gar.getPaginatedDelegatesFromAllGateways(tostring(delegates.nextCursor), 2)
 				assert.are.same({
-					limit = 1,
+					limit = 2,
 					sortBy = "delegatedStake",
 					sortOrder = "desc",
 					hasMore = false,
 					nextCursor = nil,
-					totalItems = 2,
+					totalItems = 4,
 					items = {
 						{
+							address = stubRandomAddress,
+							cursorKey = stubRandomAddress .. "_" .. stubGatewayAddress,
+							gatewayAddress = stubGatewayAddress,
+							delegatedStake = 200,
+							startTimestamp = 0,
+							vaultedStake = 200,
+						},
+						{
 							address = stubGatewayAddress,
+							cursorKey = stubGatewayAddress .. "_" .. stubRandomAddress,
 							gatewayAddress = stubRandomAddress,
 							delegatedStake = 100,
 							startTimestamp = 0,

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -2149,4 +2149,44 @@ function gar.nextRedelegationsPruneTimestamp()
 	return NextRedelegationsPruneTimestamp
 end
 
+--- @class DelegatesFromAllGateways
+--- @field address WalletAddress
+--- @field gatewayAddress WalletAddress
+--- @field startTimestamp Timestamp
+--- @field delegatedStake mARIO
+--- @field vaultedStake mARIO
+
+--- @param cursor string|nil
+--- @param limit number
+--- @param sortBy string|nil
+--- @param sortOrder string|nil
+--- @return PaginatedTable<DelegatesFromAllGateways>
+function gar.getPaginatedDelegatesFromAllGateways(cursor, limit, sortBy, sortOrder)
+	--- @type DelegatesFromAllGateways[]
+	local allDelegations = {}
+
+	for gatewayAddress, gateway in pairs(GatewayRegistry) do
+		for delegateAddress, delegate in pairs(gateway.delegates) do
+			table.insert(allDelegations, {
+				address = delegateAddress,
+				gatewayAddress = gatewayAddress,
+				startTimestamp = delegate.startTimestamp,
+				delegatedStake = delegate.delegatedStake,
+				vaultedStake = utils.reduce(delegate.vaults, function(acc, _, vault)
+					return acc + vault.balance
+				end, 0),
+			})
+		end
+	end
+
+	return utils.paginateTableWithCursor(
+		allDelegations,
+		cursor,
+		"address",
+		limit,
+		sortBy or "delegatedStake",
+		sortOrder or "desc"
+	)
+end
+
 return gar

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -2150,13 +2150,14 @@ function gar.nextRedelegationsPruneTimestamp()
 end
 
 --- @class DelegatesFromAllGateways
+--- @field cursorKey string -- delegateAddress_gatewayAddress
 --- @field address WalletAddress
 --- @field gatewayAddress WalletAddress
 --- @field startTimestamp Timestamp
 --- @field delegatedStake mARIO
 --- @field vaultedStake mARIO
 
---- @param cursor string|nil
+--- @param cursor string|nil -- cursorKey of the last item in the previous page
 --- @param limit number
 --- @param sortBy string|nil
 --- @param sortOrder string|nil
@@ -2165,9 +2166,10 @@ function gar.getPaginatedDelegatesFromAllGateways(cursor, limit, sortBy, sortOrd
 	--- @type DelegatesFromAllGateways[]
 	local allDelegations = {}
 
-	for gatewayAddress, gateway in pairs(GatewayRegistry) do
+	for gatewayAddress, gateway in pairs(gar.getGatewaysUnsafe()) do
 		for delegateAddress, delegate in pairs(gateway.delegates) do
 			table.insert(allDelegations, {
+				cursorKey = delegateAddress .. "_" .. gatewayAddress,
 				address = delegateAddress,
 				gatewayAddress = gatewayAddress,
 				startTimestamp = delegate.startTimestamp,
@@ -2182,7 +2184,7 @@ function gar.getPaginatedDelegatesFromAllGateways(cursor, limit, sortBy, sortOrd
 	return utils.paginateTableWithCursor(
 		allDelegations,
 		cursor,
-		"address",
+		"cursorKey",
 		limit,
 		sortBy or "delegatedStake",
 		sortOrder or "desc"

--- a/src/main.lua
+++ b/src/main.lua
@@ -109,7 +109,6 @@ local ActionMap = {
 	AllowDelegates = "Allow-Delegates",
 	DisallowDelegates = "Disallow-Delegates",
 	Delegations = "Delegations",
-
 	-- PRIMARY NAMES
 	RemovePrimaryNames = "Remove-Primary-Names",
 	RequestPrimaryName = "Request-Primary-Name",

--- a/src/main.lua
+++ b/src/main.lua
@@ -2533,7 +2533,7 @@ end)
 addEventingHandler("allPaginatedDelegates", utils.hasMatchingTag("Action", "All-Paginated-Delegates"), function(msg)
 	local page = utils.parsePaginationTags(msg)
 	local result = gar.getPaginatedDelegatesFromAllGateways(page.cursor, page.limit, page.sortBy, page.sortOrder)
-	Send(msg, { Target = msg.From, Action = "Delegates-Notice", Data = json.encode(result) })
+	Send(msg, { Target = msg.From, Action = "All-Delegates-Notice", Data = json.encode(result) })
 end)
 
 return process

--- a/src/main.lua
+++ b/src/main.lua
@@ -86,6 +86,7 @@ local ActionMap = {
 	CancelWithdrawal = "Cancel-Withdrawal",
 	InstantWithdrawal = "Instant-Withdrawal",
 	RedelegationFee = "Redelegation-Fee",
+	AllPaginatedDelegates = "All-Paginated-Delegates",
 	--- ArNS
 	Record = "Record",
 	Records = "Records",
@@ -108,6 +109,7 @@ local ActionMap = {
 	AllowDelegates = "Allow-Delegates",
 	DisallowDelegates = "Disallow-Delegates",
 	Delegations = "Delegations",
+
 	-- PRIMARY NAMES
 	RemovePrimaryNames = "Remove-Primary-Names",
 	RequestPrimaryName = "Request-Primary-Name",
@@ -2527,6 +2529,12 @@ addEventingHandler("getPruningTimestamps", utils.hasMatchingTag("Action", "Pruni
 			vaults = vaults.nextVaultsPruneTimestamp(),
 		}),
 	})
+end)
+
+addEventingHandler("allPaginatedDelegates", utils.hasMatchingTag("Action", "All-Paginated-Delegates"), function(msg)
+	local page = utils.parsePaginationTags(msg)
+	local result = gar.getPaginatedDelegatesFromAllGateways(page.cursor, page.limit, page.sortBy, page.sortOrder)
+	Send(msg, { Target = msg.From, Action = "Delegates-Notice", Data = json.encode(result) })
 end)
 
 return process

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -1461,7 +1461,6 @@ describe('GatewayRegistry', async () => {
           timestamp: STUB_TIMESTAMP + 2,
         });
         // parse items, nextCursor
-        console.log('paginatedDelegates', paginatedDelegates);
         const { items, nextCursor, hasMore, sortBy, sortOrder, totalItems } =
           JSON.parse(paginatedDelegates.Messages?.[0]?.Data);
         assert.equal(totalItems, 2);

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -1424,6 +1424,63 @@ describe('GatewayRegistry', async () => {
     });
   });
 
+  describe('All-Paginated-Delegates', () => {
+    it('should paginate all delegates correctly', async () => {
+      const stakeQty = 20_000_000;
+      const { memory: delegatedStakeMemory } = await delegateStake({
+        delegatorAddress,
+        quantity: stakeQty,
+        gatewayAddress: STUB_ADDRESS,
+        timestamp: STUB_TIMESTAMP,
+        memory: sharedMemory,
+      });
+      const secondDelegatorAddress = 'second-delegator-'.padEnd(43, 'b');
+      const secondStakeQty = 10_000_000;
+      const { memory: secondDelegatedStakeMemory } = await delegateStake({
+        delegatorAddress: secondDelegatorAddress,
+        quantity: secondStakeQty,
+        gatewayAddress: STUB_ADDRESS,
+        timestamp: STUB_TIMESTAMP + 1,
+        memory: delegatedStakeMemory,
+      });
+
+      let cursor;
+      let fetchedDelegates = [];
+      while (true) {
+        const paginatedDelegates = await handle({
+          options: {
+            Tags: [
+              { name: 'Action', value: 'All-Paginated-Delegates' },
+              { name: 'Cursor', value: cursor },
+              { name: 'Limit', value: '1' },
+              { name: 'Sort-By', value: 'delegatedStake' },
+              { name: 'Sort-Order', value: 'asc' },
+            ],
+          },
+          memory: secondDelegatedStakeMemory,
+          timestamp: STUB_TIMESTAMP + 2,
+        });
+        // parse items, nextCursor
+        console.log('paginatedDelegates', paginatedDelegates);
+        const { items, nextCursor, hasMore, sortBy, sortOrder, totalItems } =
+          JSON.parse(paginatedDelegates.Messages?.[0]?.Data);
+        assert.equal(totalItems, 2);
+        assert.equal(items.length, 1);
+        assert.equal(sortBy, 'delegatedStake');
+        assert.equal(sortOrder, 'asc');
+        assert.equal(hasMore, !!nextCursor);
+        cursor = nextCursor;
+        fetchedDelegates.push(...items);
+        if (!cursor) break;
+      }
+      assert.deepStrictEqual(
+        fetchedDelegates.map((d) => d.address),
+        [secondDelegatorAddress, delegatorAddress], // smaller delegated stake first with sortBy 'delegatedStake' and sortOrder 'asc'
+      );
+      sharedMemory = secondDelegatedStakeMemory;
+    });
+  });
+
   describe('Save-Observations', () => {
     const distributionTimestamp = genesisEpochTimestamp + distributionDelay;
     const observerAddress = 'observer-address-'.padEnd(43, 'a');

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -24,7 +24,7 @@ describe('handlers', async () => {
     const defaultIndex = handlersList.indexOf('_default');
     const sanitizeIndex = handlersList.indexOf('sanitize');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 72; // this should be updated if more handlers are added
+    const expectedHandlerCount = 73; // this should be updated if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
     assert.ok(sanitizeIndex === 2);


### PR DESCRIPTION
this PR adds a handler that returns paginated delegates from all gateways in the shape of 

```ts
{
  address: string, // Address of the delegate
  gatewayAddress: string, // Gateway address the stake is delegated to
  delegatedStake: number, // Amount of stake currently delegated to gateway
  startTimestamp: number, // Timestamp of when the delegate first staked to this gateway
  vaultedStake: number, // Aggregation of all stake found in any vaults found for the delegate (stake being withdrawn)
},
```