### PR TITLE
chore(test): update monitor test, remove duplicate calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "test:unit": "rm -rf coverage && mkdir -p coverage && busted . && luacov",
     "test:coverage": "rm -rf luacov-html && yarn test:unit && luacov --reporter html && open luacov-html/index.html",
     "test:integration": "yarn build && node --test --experimental-wasm-memory64 **/*.test.mjs",
-    "monitor": "node --test tests/monitor/monitor.test.mjs",
-    "monitor:devnet": "ARIO_NETWORK_PROCESS_ID=GaQrvEMKBpkjofgnBi_B3IgIDmY_XYelVLB6GcRGrHc node --test tests/monitor/monitor.test.mjs",
-    "monitor:testnet": "ARIO_NETWORK_PROCESS_ID=agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA node --test tests/monitor/monitor.test.mjs",
+    "monitor:down": "docker compose -f tests/monitor/docker-compose.test.yml down",
+    "monitor": "yarn monitor:down && node --test tests/monitor/monitor.test.mjs",
+    "monitor:devnet": "yarn monitor:down && ARIO_NETWORK_PROCESS_ID=GaQrvEMKBpkjofgnBi_B3IgIDmY_XYelVLB6GcRGrHc node --test tests/monitor/monitor.test.mjs",
+    "monitor:testnet": "yarn monitor:down && ARIO_NETWORK_PROCESS_ID=agYcCFJtrMG6cqMuZfskIkFTGvUPddICmtQSBIoPdiA node --test tests/monitor/monitor.test.mjs",
     "evolve": "yarn build && node tools/evolve.mjs",
     "prepare": "husky"
   },
@@ -21,6 +22,7 @@
     "arweave": "^1.15.1",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
+    "p-limit": "^6.2.0",
     "prettier": "^3.3.2",
     "testcontainers": "^10.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
-    "@ar.io/sdk": "^3.1.0-alpha.9",
+    "@ar.io/sdk": "^3.3.0",
     "@permaweb/ao-loader": "^0.0.36",
     "@permaweb/aoconnect": "^0.0.59",
     "arweave": "^1.15.1",

--- a/tests/monitor/monitor.test.mjs
+++ b/tests/monitor/monitor.test.mjs
@@ -469,7 +469,6 @@ describe('setup', () => {
       const { items: delegates } = await io.getAllDelegates({
         limit: 10_000,
       });
-      // this overwhelms the local CU, so keep in a for loop
       await Promise.all(
         delegates.map((delegate) =>
           throttle(async () => {

--- a/tests/monitor/monitor.test.mjs
+++ b/tests/monitor/monitor.test.mjs
@@ -3,6 +3,7 @@ import { connect } from '@permaweb/aoconnect';
 import { strict as assert } from 'node:assert';
 import { describe, it, before, after } from 'node:test';
 import { DockerComposeEnvironment, Wait } from 'testcontainers';
+import pLimit from 'p-limit';
 
 // set debug level logs for to get detailed messages
 Logger.default.setLogLevel('info');
@@ -21,6 +22,7 @@ const io = ARIO.init({
 });
 
 const projectRootPath = process.cwd();
+const throttle = pLimit(25);
 
 describe('setup', () => {
   let compose;
@@ -29,9 +31,8 @@ describe('setup', () => {
       projectRootPath,
       'tests/monitor/docker-compose.test.yml',
     )
-      .withBuild()
-      .withWaitStrategy('ao-cu-1', Wait.forHttp(`/state/${processId}`, 6363))
-      .up(['ao-cu']);
+      .withWaitStrategy('ao-cu', Wait.forHttp(`/state/${processId}`, 6363))
+      .up();
   });
 
   after(async () => {
@@ -387,17 +388,6 @@ describe('setup', () => {
 
   // gateway registry - ensure no invalid gateways
   describe('gateway registry', () => {
-    let gateways = [];
-    let totalGateways = [];
-
-    before(async () => {
-      const gatewaysResponse = await io.getGateways({
-        limit: 1000,
-      });
-      gateways = gatewaysResponse.items;
-      totalGateways = gatewaysResponse.totalItems;
-    });
-
     it('should only have valid gateways', { timeout: 60000 }, async () => {
       const { durationMs, epochZeroStartTimestamp } =
         await io.getEpochSettings();
@@ -406,60 +396,69 @@ describe('setup', () => {
         (Date.now() - epochZeroStartTimestamp) / durationMs,
       );
 
+      const { items: gateways, totalItems: totalGateways } =
+        await io.getGateways({
+          limit: 10_000,
+        });
+
       const uniqueGateways = new Set();
-      for (const gateway of gateways) {
-        uniqueGateways.add(gateway.gatewayAddress);
-        if (gateway.status === 'joined') {
-          assert(
-            Number.isInteger(gateway.operatorStake),
-            `Gateway ${gateway.gatewayAddress} has an invalid operator stake: ${gateway.operatorStake}`,
-          );
-          assert(
-            Number.isInteger(gateway.totalDelegatedStake),
-            `Gateway ${gateway.gatewayAddress} has an invalid total delegated stake: ${gateway.totalDelegatedStake}`,
-          );
-          assert(
-            gateway.operatorStake >= 10_000_000_000,
-            `Gateway ${gateway.gatewayAddress} has less than 10_000_000_000 ARIO staked`,
-          );
-          assert(
-            gateway.stats.failedConsecutiveEpochs >= 0,
-            `Gateway ${gateway.gatewayAddress} has less than 0 failed consecutive epochs`,
-          );
-          assert(
-            gateway.stats.failedConsecutiveEpochs < 30,
-            `Gateway ${gateway.gatewayAddress} has more than 30 failed consecutive epochs`,
-          );
-          assert(
-            gateway.stats.passedConsecutiveEpochs <= currentEpochIndex,
-            `Gateway ${gateway.gatewayAddress} has more passed consecutive epochs than current epoch index`,
-          );
-          assert(
-            gateway.stats.passedConsecutiveEpochs >= 0,
-            `Gateway ${gateway.gatewayAddress} has less than 0 passed consecutive epochs`,
-          );
-          assert(
-            gateway.stats.totalEpochCount <= currentEpochIndex,
-            `Gateway ${gateway.gatewayAddress} has more total epochs than current epoch index`,
-          );
-          assert(
-            gateway.stats.totalEpochCount >= 0,
-            `Gateway ${gateway.gatewayAddress} has less than 0 total epochs`,
-          );
-          assert(
-            gateway.stats.prescribedEpochCount <= currentEpochIndex,
-            `Gateway ${gateway.gatewayAddress} has more prescribed epochs than current epoch index`,
-          );
-          assert(
-            gateway.stats.prescribedEpochCount >= 0,
-            `Gateway ${gateway.gatewayAddress} has less than 0 prescribed epochs`,
-          );
-        }
-        if (gateway.status === 'leaving') {
-          assert(gateway.totalDelegatedStake === 0);
-          assert(gateway.operatorStake === 0);
-        }
-      }
+      await Promise.all(
+        gateways.map((gateway) =>
+          throttle(async () => {
+            uniqueGateways.add(gateway.gatewayAddress);
+            if (gateway.status === 'joined') {
+              assert(
+                Number.isInteger(gateway.operatorStake),
+                `Gateway ${gateway.gatewayAddress} has an invalid operator stake: ${gateway.operatorStake}`,
+              );
+              assert(
+                Number.isInteger(gateway.totalDelegatedStake),
+                `Gateway ${gateway.gatewayAddress} has an invalid total delegated stake: ${gateway.totalDelegatedStake}`,
+              );
+              assert(
+                gateway.operatorStake >= 10_000_000_000,
+                `Gateway ${gateway.gatewayAddress} has less than 10_000_000_000 ARIO staked`,
+              );
+              assert(
+                gateway.stats.failedConsecutiveEpochs >= 0,
+                `Gateway ${gateway.gatewayAddress} has less than 0 failed consecutive epochs`,
+              );
+              assert(
+                gateway.stats.failedConsecutiveEpochs < 30,
+                `Gateway ${gateway.gatewayAddress} has more than 30 failed consecutive epochs`,
+              );
+              assert(
+                gateway.stats.passedConsecutiveEpochs <= currentEpochIndex,
+                `Gateway ${gateway.gatewayAddress} has more passed consecutive epochs than current epoch index`,
+              );
+              assert(
+                gateway.stats.passedConsecutiveEpochs >= 0,
+                `Gateway ${gateway.gatewayAddress} has less than 0 passed consecutive epochs`,
+              );
+              assert(
+                gateway.stats.totalEpochCount <= currentEpochIndex,
+                `Gateway ${gateway.gatewayAddress} has more total epochs than current epoch index`,
+              );
+              assert(
+                gateway.stats.totalEpochCount >= 0,
+                `Gateway ${gateway.gatewayAddress} has less than 0 total epochs`,
+              );
+              assert(
+                gateway.stats.prescribedEpochCount <= currentEpochIndex,
+                `Gateway ${gateway.gatewayAddress} has more prescribed epochs than current epoch index`,
+              );
+              assert(
+                gateway.stats.prescribedEpochCount >= 0,
+                `Gateway ${gateway.gatewayAddress} has less than 0 prescribed epochs`,
+              );
+            }
+            if (gateway.status === 'leaving') {
+              assert(gateway.totalDelegatedStake === 0);
+              assert(gateway.operatorStake === 0);
+            }
+          }),
+        ),
+      );
       assert(
         uniqueGateways.size === totalGateways,
         `Counted total gateways (${uniqueGateways.size}) does not match total gateways (${totalGateways})`,
@@ -467,87 +466,58 @@ describe('setup', () => {
     });
 
     it('should have valid delegates for all gateways', async () => {
-      // NOTE: this is an attempt to get the delegates for a gateway, the UX is not great so consider modifying or adding handlers to support gateway specific delegation filters
-      for (const gateway of gateways) {
-        const { items: delegates } = await io.getGatewayDelegates({
-          address: gateway.gatewayAddress,
-        });
-        if (delegates.length > 0) {
-          for (const delegate of delegates) {
+      const { items: delegates } = await io.getAllDelegates({
+        limit: 10_000,
+      });
+      // this overwhelms the local CU, so keep in a for loop
+      await Promise.all(
+        delegates.map((delegate) =>
+          throttle(async () => {
             assert(
               delegate.delegatedStake >= 0 && delegate.startTimestamp > 0,
-              `Gateway ${gateway.gatewayAddress} has invalid delegate`,
+              `Gateway ${delegate.gatewayAddress} has invalid delegate`,
             );
-            const { items: allDelegations } = await io.getDelegations({
-              address: delegate.address,
-              limit: 1000,
-            });
-            const delegations = allDelegations.filter(
-              (delegation) =>
-                delegation.gatewayAddress === gateway.gatewayAddress,
-            );
-            const stakes = delegations.filter(
-              (delegation) => delegation.type === 'stake',
-            );
-            const vaults = delegations.filter(
-              (delegation) => delegation.type === 'vault',
-            );
-            for (const stake of stakes) {
-              assert(
-                stake.balance >= 0, // can be 0 if the delegate is unstaking
-                `Gateway ${gateway.gatewayAddress} has invalid stake for delegate ${delegate.address}: ${stake.balance}`,
-              );
-              assert(
-                stake.startTimestamp > 0,
-                `Gateway ${gateway.gatewayAddress} has invalid stake start timestamp for delegate ${delegate.address}: ${stake.startTimestamp}`,
-              );
-            }
-            for (const vault of vaults) {
-              assert(
-                vault.balance > 0, // should never be zero
-                `Gateway ${gateway.gatewayAddress} has invalid vault for delegate ${delegate.address}: ${vault.balance}`,
-              );
-              assert(
-                vault.startTimestamp > 0 &&
-                  vault.endTimestamp > vault.startTimestamp,
-                `Gateway ${gateway.gatewayAddress} has invalid vault start and end timestamps for delegate ${delegate.address}: ${vault.startTimestamp} and ${vault.endTimestamp}`,
-              );
-            }
-          }
-        }
-      }
+            // TODO: assert it's a valid gateway that is active
+            assert(delegate.gatewayAddress, 'Gateway address is invalid');
+            assert(delegate.vaultedStake >= 0, 'Vaulted stake is invalid');
+          }),
+        ),
+      );
     });
 
     it('should have valid vaults for all gateways', async () => {
-      for (const gateway of gateways) {
-        const { items: vaults } = await io.getGatewayVaults({
-          address: gateway.gatewayAddress,
-        });
-        if (vaults.length === 0) {
-          for (const vault of vaults) {
-            // assert vault balance is greater than 0 and startTimestamp and endTimestamp are valid timestamps (they are all set to 90 by default, but old ones have to expire out)
-            assert(
-              Number.isInteger(vault.balance),
-              `Vault ${vaultId} on gateway ${gateway.gatewayAddress} has an invalid balance (${vault.balance})`,
-            );
-            assert(
-              vault.balance >= 0,
-              `Vault ${vaultId} on gateway ${gateway.gatewayAddress} has an invalid balance (${vault.balance})`,
-            );
-            assert(
-              vault.startTimestamp > 0,
-              `Vault ${vaultId} on gateway ${gateway.gatewayAddress} has an invalid start timestamp (${vault.startTimestamp})`,
-            );
-            assert(
-              vault.endTimestamp > 0,
-              `Vault ${vault.vaultId} on gateway ${gateway.gatewayAddress} has an invalid end timestamp (${vault.endTimestamp})`,
-            );
-            assert(
-              vault.endTimestamp > vault.startTimestamp,
-              `Vault ${vault.vaultId} on gateway ${gateway.gatewayAddress} has an invalid end timestamp (${vault.endTimestamp})`,
-            );
-          }
-        }
+      const { items: vaults } = await io.getAllGatewayVaults({
+        limit: 10_000,
+      });
+      if (vaults.length > 0) {
+        // Fixed inverted logic
+        await Promise.all(
+          vaults.map((vault) =>
+            throttle(async () => {
+              // assert vault balance is greater than 0 and startTimestamp and endTimestamp are valid timestamps (they are all set to 90 by default, but old ones have to expire out)
+              assert(
+                Number.isInteger(vault.balance),
+                `Vault ${vault.vaultId} on gateway ${vault.gatewayAddress} has an invalid balance (${vault.balance})`, // Fixed vaultId reference
+              );
+              assert(
+                vault.balance >= 0,
+                `Vault ${vault.vaultId} on gateway ${vault.gatewayAddress} has an invalid balance (${vault.balance})`, // Fixed vaultId reference
+              );
+              assert(
+                vault.startTimestamp > 0,
+                `Vault ${vault.vaultId} on gateway ${vault.gatewayAddress} has an invalid start timestamp (${vault.startTimestamp})`, // Fixed vaultId reference
+              );
+              assert(
+                vault.endTimestamp > 0,
+                `Vault ${vault.vaultId} on gateway ${vault.gatewayAddress} has an invalid end timestamp (${vault.endTimestamp})`,
+              );
+              assert(
+                vault.endTimestamp > vault.startTimestamp,
+                `Vault ${vault.vaultId} on gateway ${vault.gatewayAddress} has an invalid end timestamp (${vault.endTimestamp})`,
+              );
+            }),
+          ),
+        );
       }
     });
   });
@@ -555,55 +525,55 @@ describe('setup', () => {
   // arns registry - ensure no invalid arns
   describe('arns names', () => {
     const twoWeeks = 2 * 7 * 24 * 60 * 60 * 1000;
-    let arnsRecords = {};
-    let totalArNSRecords;
 
-    before(async () => {
-      const recordResponse = await io.getArNSRecords({
-        limit: 10000,
-      });
-      arnsRecords = recordResponse.items;
-      totalArNSRecords = recordResponse.totalItems;
-    });
     it(
       'should not have any arns records older than two weeks',
       { timeout: 60000 },
       async () => {
+        const { items: arnsRecords, totalItems: totalArNSRecords } =
+          await io.getArNSRecords({
+            limit: 10000,
+          });
         const uniqueNames = new Set();
-        for (const arn of arnsRecords) {
-          uniqueNames.add(arn.name);
-          assert(arn.processId, `ARNs name '${arn.name}' has no processId`);
-          assert(arn.type, `ARNs name '${arn.name}' has no type`);
-          assert(
-            arn.startTimestamp,
-            `ARNs name '${arn.name}' has no start timestamp`,
-          );
-          assert(
-            Number.isInteger(arn.purchasePrice) && arn.purchasePrice >= 0,
-            `ARNs name '${arn.name}' has invalid purchase price: ${arn.purchasePrice}`,
-          );
-          assert(
-            Number.isInteger(arn.undernameLimit) && arn.undernameLimit >= 10,
-            `ARNs name '${arn.name}' has invalid undername limit: ${arn.undernameLimit}`,
-          );
-          if (arns.type === 'lease') {
-            assert(
-              arn.endTimestamp,
-              `ARNs name '${arn.name}' has no end timestamp`,
-            );
-            assert(
-              arn.endTimestamp > Date.now() - twoWeeks,
-              `ARNs name '${arn.name}' is older than two weeks`,
-            );
-          }
-          // if permabuy, assert no endTimestamp
-          if (arn.type === 'permabuy') {
-            assert(
-              !arn.endTimestamp,
-              `ARNs name '${arn.name}' has an end timestamp`,
-            );
-          }
-        }
+        await Promise.all(
+          arnsRecords.map((arn) =>
+            throttle(async () => {
+              uniqueNames.add(arn.name);
+              assert(arn.processId, `ARNs name '${arn.name}' has no processId`);
+              assert(arn.type, `ARNs name '${arn.name}' has no type`);
+              assert(
+                arn.startTimestamp,
+                `ARNs name '${arn.name}' has no start timestamp`,
+              );
+              assert(
+                Number.isInteger(arn.purchasePrice) && arn.purchasePrice >= 0,
+                `ARNs name '${arn.name}' has invalid purchase price: ${arn.purchasePrice}`,
+              );
+              assert(
+                Number.isInteger(arn.undernameLimit) &&
+                  arn.undernameLimit >= 10,
+                `ARNs name '${arn.name}' has invalid undername limit: ${arn.undernameLimit}`,
+              );
+              if (arn.type === 'lease') {
+                assert(
+                  arn.endTimestamp,
+                  `ARNs name '${arn.name}' has no end timestamp`,
+                );
+                assert(
+                  arn.endTimestamp > Date.now() - twoWeeks,
+                  `ARNs name '${arn.name}' is older than two weeks`,
+                );
+              }
+              // if permabuy, assert no endTimestamp
+              if (arn.type === 'permabuy') {
+                assert(
+                  !arn.endTimestamp,
+                  `ARNs name '${arn.name}' has an end timestamp`,
+                );
+              }
+            }),
+          ),
+        );
         assert(
           uniqueNames.size === totalArNSRecords,
           `Counted total ARNs (${uniqueNames.size}) does not match total ARNs (${totalArNSRecords})`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@ar.io/sdk@^3.1.0-alpha.9":
-  version "3.1.0-alpha.9"
-  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.1.0-alpha.9.tgz#d6c148ec494afaf9f27523ba5be82b4ee1fb29c4"
-  integrity sha512-VQhI9XVNqQAjylRFNy/20glEuLOfZvuEeKrVsMX6JRDrYV3BvWeJBVG1swManaikRdEzENmCH0MwBkr6fjSVEA==
+"@ar.io/sdk@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ar.io/sdk/-/sdk-3.3.0.tgz#a73488c08de4d0f25ff3dab0ee427127c9080672"
+  integrity sha512-Q9/qPmiu6UUZGEWAYweXPIhMPhPMKJU0imwSngd+hijJHxGEA4NWWwyW/OPcb/bL4rre+uLIUdcD0cDjSekoWw==
   dependencies:
     "@dha-team/arbundles" "^1.0.1"
     "@permaweb/aoconnect" "^0.0.57"
-    arweave "1.14.4"
+    arweave "1.15.5"
     axios "1.7.9"
     axios-retry "^4.3.0"
     commander "^12.1.0"
@@ -593,17 +593,7 @@ arweave-stream-tx@^1.1.0:
   dependencies:
     exponential-backoff "^3.1.0"
 
-arweave@1.14.4:
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.14.4.tgz#5ba22136aa0e7fd9495258a3931fb770c9d6bf21"
-  integrity sha512-tmqU9fug8XAmFETYwgUhLaD3WKav5DaM4p1vgJpEj/Px2ORPPMikwnSySlFymmL2qgRh2ZBcZsg11+RXPPGLsA==
-  dependencies:
-    arconnect "^0.4.2"
-    asn1.js "^5.4.1"
-    base64-js "^1.5.1"
-    bignumber.js "^9.0.2"
-
-arweave@^1.10.13, arweave@^1.13.7, arweave@^1.15.1:
+arweave@1.15.5, arweave@^1.10.13, arweave@^1.13.7, arweave@^1.15.1:
   version "1.15.5"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.15.5.tgz#d0fb209de01bfc9dc97d5da70270928a83ecee83"
   integrity sha512-Zj3b8juz1ZtDaQDPQlzWyk2I4wZPx3RmcGq8pVJeZXl2Tjw0WRy5ueHPelxZtBLqCirGoZxZEAFRs6SZUSCBjg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,6 +1552,13 @@ onetime@^7.0.0:
   dependencies:
     mimic-function "^5.0.0"
 
+p-limit@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-6.2.0.tgz#c254d22ba6aeef441a3564c5e6c2f2da59268a0f"
+  integrity sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==
+  dependencies:
+    yocto-queue "^1.1.1"
+
 package-json-from-dist@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
@@ -2170,6 +2177,11 @@ yaml@~2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.1.tgz#c9772aacf62cb7494a95b0c4f1fb065b563db130"
   integrity sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==
+
+yocto-queue@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.1.1.tgz#fef65ce3ac9f8a32ceac5a634f74e17e5b232110"
+  integrity sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==
 
 zip-stream@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
These tests take ~10-15 mins to run in CI. That is too long. This leverages pLimit to concurrently execute tests, and moves some API calls up to avoid calling them multiple times across tests. There are more improvements we can make to run them concurrently (splitting into separate files), but this is sufficient for now.

These now run in 30-40 seconds on testnet.

```
ℹ tests 13
ℹ suites 9
ℹ pass 13
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 35717.852429
✨  Done in 37.58s.
```

