### PR TITLE
chore(epochs): remove old epochs

### DIFF
--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -28,7 +28,6 @@ local epochs = {}
 --- @field prescribedObservers WeightedGateway[] The prescribed observers of the epoch
 
 --- @class EpochSettings
---- @field pruneEpochsCount number The number of epochs to prune
 --- @field prescribedNameCount number The number of prescribed names
 --- @field rewardPercentage number The reward percentage
 --- @field maxObservers number The maximum number of observers
@@ -77,7 +76,6 @@ local epochs = {}
 Epochs = Epochs or {}
 EpochSettings = EpochSettings
 	or {
-		pruneEpochsCount = 14, -- prune epochs older than 14 days
 		prescribedNameCount = 2,
 		maxObservers = 50,
 		epochZeroStartTimestamp = 1719900000000, -- July 9th, 00:00:00 UTC
@@ -590,13 +588,11 @@ function epochs.computeTotalEligibleRewardsForEpoch(epochIndex, prescribedObserv
 		potentialRewards = potentialRewards,
 	}
 end
---- Distributes the rewards for an epoch
---- 1. Get gateways participated in full epoch based on start and end timestamp
---- 2. Get the prescribed observers for the relevant epoch
---- 3. Calculate the rewards for the epoch based on protocol balance
---- 4. Allocate 95% of the rewards for passed gateways, 5% for observers - based on total gateways during the epoch and # of prescribed observers
---- 5. Distribute the rewards to the gateways and observers
---- 6. Increment the epoch stats for the gateways
+--- Distributes the rewards for a prescribed epoch
+--- 1. Calculate the rewards for the epoch based on protocol balance
+--- 2. Allocate 95% of the rewards for passed gateways, 5% for observers - based on total gateways during the epoch and # of prescribed observers
+--- 3. Distribute the rewards to the gateways and observers
+--- 4. Increment the epoch stats for the gateways
 --- @param currentTimestamp number The current timestamp
 --- @return DistributedEpoch | nil # The updated epoch with the distributed rewards, or nil if no rewards were distributed
 function epochs.distributeRewardsForEpoch(currentTimestamp)
@@ -604,7 +600,7 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 	local epoch = epochs.getEpoch(epochIndex)
 	if not next(epoch) then
 		-- silently return
-		print("Not distributing rewards for last epoch.")
+		print("Not distributing rewards for last epoch. New epoch has not been created yet.")
 		return
 	end
 
@@ -742,9 +738,8 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 
 	-- create a distributed epoch from the prescribed epoch
 	local distributedEpoch = convertPrescribedEpochToDistributedEpoch(epoch, currentTimestamp, distributed)
-
-	-- update the epochs -- TODO: remove this from state
-	Epochs[epochIndex] = distributedEpoch
+	-- remove the epoch from the epoch table
+	Epochs[epochIndex] = nil
 	return distributedEpoch
 end
 
@@ -791,11 +786,11 @@ function epochs.pruneEpochs(timestamp)
 	--- Reset the next pruning timestamp
 	NextEpochsPruneTimestamp = nil
 	local currentEpochIndex = epochs.getEpochIndexForTimestamp(timestamp)
-	local cutoffEpochIndex = currentEpochIndex - epochs.getSettings().pruneEpochsCount
+	local cutoffEpochIndex = currentEpochIndex - 1 -- keep the two most recent epochs, on distribution the last epoch will remove itself
 	local unsafeEpochs = epochs.getEpochsUnsafe()
 	local nextEpochIndex = next(unsafeEpochs)
 	while nextEpochIndex do
-		if nextEpochIndex <= cutoffEpochIndex then
+		if nextEpochIndex < cutoffEpochIndex then
 			table.insert(prunedEpochIndexes, nextEpochIndex)
 			-- Safe to assign to nil during next() iteration
 			Epochs[nextEpochIndex] = nil

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -786,7 +786,7 @@ function epochs.pruneEpochs(timestamp)
 	--- Reset the next pruning timestamp
 	NextEpochsPruneTimestamp = nil
 	local currentEpochIndex = epochs.getEpochIndexForTimestamp(timestamp)
-	local cutoffEpochIndex = currentEpochIndex - 1 -- keep the two most recent epochs, on distribution the last epoch will remove itself
+	local cutoffEpochIndex = currentEpochIndex - 1 -- keep the two most recent epochs, on distribution the previous epoch will remove itself
 	local unsafeEpochs = epochs.getEpochsUnsafe()
 	local nextEpochIndex = next(unsafeEpochs)
 	while nextEpochIndex do

--- a/tests/epochs.test.mjs
+++ b/tests/epochs.test.mjs
@@ -144,7 +144,6 @@ describe('epochs', () => {
         durationMs: epochLength,
         distributionDelayMs: distributionDelay,
         prescribedNameCount: 2,
-        pruneEpochsCount: 14,
       });
     });
   });


### PR DESCRIPTION
Now that we post epoch distributions we no longer need to store them in state. This should give us material memory savings, but we will validate using lua memory collector in devnet before we cleanup other functions related to pruning.