### PR TITLE
PE-7514: revoked vaults

### DIFF
--- a/spec/vaults_spec.lua
+++ b/spec/vaults_spec.lua
@@ -293,7 +293,7 @@ describe("vaults", function()
 		end)
 	end)
 
-	describe("revokeVaultedTransfer", function()
+	describe("revokeVault", function()
 		local controller = "test-this-is-valid-arweave-wallet-address-1"
 		local recipient = "test-this-is-valid-arweave-wallet-address-2"
 
@@ -311,7 +311,7 @@ describe("vaults", function()
 		end)
 
 		it("should revoke a vault when from the controller", function()
-			local revokedVault = vaults.revokeVaultedTransfer(controller, recipient, "vaultId", 0)
+			local revokedVault = vaults.revokeVault(controller, recipient, "vaultId", 0)
 			assert.are.equal(100, _G.Balances[controller])
 			assert.are.same({
 				balance = 100,
@@ -322,19 +322,19 @@ describe("vaults", function()
 		end)
 
 		it("should throw an error if the vault is expired", function()
-			local status, result = pcall(vaults.revokeVaultedTransfer, controller, recipient, "vaultId", 1001)
+			local status, result = pcall(vaults.revokeVault, controller, recipient, "vaultId", 1001)
 			assert.is_false(status)
 			assert.match("Vault has ended.", result)
 		end)
 
 		it("should throw an error if the vault is not found", function()
-			local status, result = pcall(vaults.revokeVaultedTransfer, controller, recipient, "nonExistentId", 0)
+			local status, result = pcall(vaults.revokeVault, controller, recipient, "nonExistentId", 0)
 			assert.is_false(status)
 			assert.match("Vault not found.", result)
 		end)
 
 		it("should throw an error if the sender is not the controller", function()
-			local status, result = pcall(vaults.revokeVaultedTransfer, recipient, recipient, "vaultId", 0)
+			local status, result = pcall(vaults.revokeVault, recipient, recipient, "vaultId", 0)
 			assert.is_false(status)
 			assert.match("Only the controller can revoke the vault.", result)
 		end)

--- a/spec/vaults_spec.lua
+++ b/spec/vaults_spec.lua
@@ -1,7 +1,6 @@
 local vaults = require("vaults")
 local constants = require("constants")
 local utils = require("utils")
-local json = require("json")
 local startTimestamp = 0
 
 describe("vaults", function()
@@ -299,7 +298,6 @@ describe("vaults", function()
 		local recipient = "stub-recipient-address"
 
 		before_each(function()
-			print(json.encode(_G.Balances))
 			_G.Vaults = {
 				[recipient] = {
 					["vaultId"] = {

--- a/spec/vaults_spec.lua
+++ b/spec/vaults_spec.lua
@@ -1,6 +1,7 @@
 local vaults = require("vaults")
 local constants = require("constants")
 local utils = require("utils")
+local json = require("json")
 local startTimestamp = 0
 
 describe("vaults", function()
@@ -294,10 +295,11 @@ describe("vaults", function()
 	end)
 
 	describe("revokeVault", function()
-		local controller = "test-this-is-valid-arweave-wallet-address-1"
-		local recipient = "test-this-is-valid-arweave-wallet-address-2"
+		local controller = "stub-controller-address"
+		local recipient = "stub-recipient-address"
 
 		before_each(function()
+			print(json.encode(_G.Balances))
 			_G.Vaults = {
 				[recipient] = {
 					["vaultId"] = {
@@ -311,6 +313,7 @@ describe("vaults", function()
 		end)
 
 		it("should revoke a vault when from the controller", function()
+			assert.are.equal(nil, _G.Balances[controller])
 			local revokedVault = vaults.revokeVault(controller, recipient, "vaultId", 0)
 			assert.are.equal(100, _G.Balances[controller])
 			assert.are.same({

--- a/src/main.lua
+++ b/src/main.lua
@@ -786,7 +786,7 @@ addEventingHandler(ActionMap.RevokeVault, utils.hasMatchingTag("Action", ActionM
 	assert(utils.isValidAddress(vaultId, true), "Invalid vault id")
 	assert(utils.isValidAddress(recipient, true), "Invalid recipient")
 
-	local vault = vaults.revokeVaultedTransfer(msg.From, recipient, vaultId, msg.Timestamp)
+	local vault = vaults.revokeVault(msg.From, recipient, vaultId, msg.Timestamp)
 
 	msg.ioEvent:addField("Vault-Id", vaultId)
 	msg.ioEvent:addField("Vault-Recipient", recipient)

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -689,6 +689,7 @@ function utils.validateAndSanitizeInputs(table)
 	local knownBooleanTags = {
 		"Allow-Unsafe-Addresses",
 		"Force-Prune",
+		"Revokable",
 	}
 	for _, tagName in ipairs(knownBooleanTags) do
 		sanitizedTable[tagName] = sanitizedTable[tagName]

--- a/src/vaults.lua
+++ b/src/vaults.lua
@@ -101,9 +101,9 @@ function vaults.revokeVault(controller, recipient, vaultId, currentTimestamp)
 	local vault = vaults.getVault(recipient, vaultId)
 	assert(vault, "Vault not found.")
 	assert(vault.controller == controller, "Only the controller can revoke the vault.")
-	assert(currentTimestamp <= vault.endTimestamp, "Vault has ended.")
+	assert(currentTimestamp < vault.endTimestamp, "Vault has ended.")
 
-	balances.increaseBalance(recipient, vault.balance)
+	balances.increaseBalance(controller, vault.balance)
 	Vaults[recipient][vaultId] = nil
 	return vault
 end

--- a/src/vaults.lua
+++ b/src/vaults.lua
@@ -1,20 +1,22 @@
-Vaults = Vaults or {}
-
 -- Utility functions that modify global Vaults object
 local vaults = {}
 local balances = require("balances")
 local utils = require("utils")
 local constants = require("constants")
 
+--- @class Vault
+--- @field balance mARIO The balance of the vault
+--- @field controller WalletAddress | nil The controller of a revokable vault. Nil if not revokable (default: nil)
+--- @field startTimestamp Timestamp The start timestamp of the vault
+--- @field endTimestamp Timestamp The end timestamp of the vault
+
+--- @alias Vaults table<WalletAddress, table<VaultId, Vault>> -- A table of vaults indexed by owner address, then by vault id
+
+--- @type Vaults
+Vaults = Vaults or {}
+
 --- @type Timestamp|nil
 NextBalanceVaultsPruneTimestamp = NextBalanceVaultsPruneTimestamp or 0
-
---- @class Vault
---- @field balance number The balance of the vault
---- @field startTimestamp number The start timestamp of the vault
---- @field endTimestamp number The end timestamp of the vault
-
---- @class Vaults: table<string, Vault> A table of vaults indexed by owner address
 
 --- Creates a vault
 --- @param from string The address of the owner
@@ -22,7 +24,7 @@ NextBalanceVaultsPruneTimestamp = NextBalanceVaultsPruneTimestamp or 0
 --- @param lockLengthMs number The lock length in milliseconds
 --- @param currentTimestamp number The current timestamp
 --- @param vaultId string The vault id
---- @return Vault The created vault
+--- @return Vault -- The created vault
 function vaults.createVault(from, qty, lockLengthMs, currentTimestamp, vaultId)
 	assert(qty > 0, "Quantity must be greater than 0")
 	assert(not vaults.getVault(from, vaultId), "Vault with id " .. vaultId .. " already exists")
@@ -53,8 +55,18 @@ end
 --- @param currentTimestamp number The current timestamp
 --- @param vaultId string The vault id
 --- @param allowUnsafeAddresses boolean|nil Whether to allow unsafe addresses, since this results in funds eventually being sent to an invalid address
---- @return Vault The created vault
-function vaults.vaultedTransfer(from, recipient, qty, lockLengthMs, currentTimestamp, vaultId, allowUnsafeAddresses)
+--- @param revokable boolean|nil Whether the vault is revokable
+--- @return Vault -- The created vault
+function vaults.vaultedTransfer(
+	from,
+	recipient,
+	qty,
+	lockLengthMs,
+	currentTimestamp,
+	vaultId,
+	allowUnsafeAddresses,
+	revokable
+)
 	assert(utils.isValidAddress(recipient, allowUnsafeAddresses), "Invalid recipient")
 	assert(qty > 0, "Quantity must be greater than 0")
 	assert(recipient ~= from, "Cannot transfer to self")
@@ -74,8 +86,26 @@ function vaults.vaultedTransfer(from, recipient, qty, lockLengthMs, currentTimes
 		balance = qty,
 		startTimestamp = currentTimestamp,
 		endTimestamp = currentTimestamp + lockLengthMs,
+		controller = revokable and from or nil,
 	})
 	return newVault
+end
+
+--- Revokes a vaulted transfer
+---@param from WalletAddress
+---@param recipient WalletAddress
+---@param vaultId VaultId
+---@param currentTimestamp Timestamp
+---@return Vault
+function vaults.revokeVaultedTransfer(from, recipient, vaultId, currentTimestamp)
+	local vault = vaults.getVault(recipient, vaultId)
+	assert(vault, "Vault not found.")
+	assert(vault.controller == from, "Only the controller can revoke the vault.")
+	assert(currentTimestamp <= vault.endTimestamp, "Vault has ended.")
+
+	balances.increaseBalance(recipient, vault.balance)
+	Vaults[recipient][vaultId] = nil
+	return vault
 end
 
 --- Extends a vault

--- a/src/vaults.lua
+++ b/src/vaults.lua
@@ -55,7 +55,7 @@ end
 --- @param currentTimestamp number The current timestamp
 --- @param vaultId string The vault id
 --- @param allowUnsafeAddresses boolean|nil Whether to allow unsafe addresses, since this results in funds eventually being sent to an invalid address
---- @param revokable boolean|nil Whether the vault is revokable
+--- @param revokable boolean|nil Whether the vault is revokable. Defaults to nil
 --- @return Vault -- The created vault
 function vaults.vaultedTransfer(
 	from,
@@ -91,16 +91,16 @@ function vaults.vaultedTransfer(
 	return newVault
 end
 
---- Revokes a vaulted transfer
----@param from WalletAddress
----@param recipient WalletAddress
----@param vaultId VaultId
----@param currentTimestamp Timestamp
+--- Revokes a vaulted transfer back to the controller
+---@param controller WalletAddress The address of the controller of a revokable vault. This is the signer of the vaultedTransfer
+---@param recipient WalletAddress The address of the recipient of the vaultedTransfer
+---@param vaultId VaultId The id of the vault to revoke
+---@param currentTimestamp Timestamp The current timestamp
 ---@return Vault
-function vaults.revokeVaultedTransfer(from, recipient, vaultId, currentTimestamp)
+function vaults.revokeVault(controller, recipient, vaultId, currentTimestamp)
 	local vault = vaults.getVault(recipient, vaultId)
 	assert(vault, "Vault not found.")
-	assert(vault.controller == from, "Only the controller can revoke the vault.")
+	assert(vault.controller == controller, "Only the controller can revoke the vault.")
 	assert(currentTimestamp <= vault.endTimestamp, "Vault has ended.")
 
 	balances.increaseBalance(recipient, vault.balance)

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -24,7 +24,7 @@ describe('handlers', async () => {
     const defaultIndex = handlersList.indexOf('_default');
     const sanitizeIndex = handlersList.indexOf('sanitize');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 75; // this should be updated if more handlers are added
+    const expectedHandlerCount = 76; // this should be updated if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
     assert.ok(sanitizeIndex === 2);


### PR DESCRIPTION
this PR:

- on vaulted-transfer: when in Tags: `{name: "Revokable": value: "true"}` -- add `controller` property to the vault populated with `msg.From` (signer of the message)
- adds new new revoke-vault handler 