### PR TITLE
fix(epochs): ensure previous epoch has been distributed before creati…

### DIFF
--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -458,131 +458,128 @@ describe("epochs", function()
 	end)
 
 	describe("createEpoch", function()
-		it(
-			"should create a new epoch for the given timestamp if there is no previous epoch that has not been distributed",
-			function()
-				_G.Epochs = {}
-				_G.GatewayRegistry = {
-					["test-this-is-valid-arweave-wallet-address-1"] = {
-						operatorStake = gar.getSettings().operators.minStake,
-						totalDelegatedStake = 0,
-						vaults = {},
-						delegates = {},
-						startTimestamp = 0,
-						stats = {
-							prescribedEpochCount = 0,
-							observedEpochCount = 0,
-							totalEpochCount = 0,
-							passedEpochCount = 0,
-							failedEpochCount = 0,
-							failedConsecutiveEpochs = 0,
-							passedConsecutiveEpochs = 0,
-						},
-						settings = testSettings,
-						status = "joined",
-						observerAddress = "test-this-is-valid-arweave-wallet-address-1",
-						weights = {
-							stakeWeight = 0,
-							tenureWeight = 0,
-							gatewayRewardRatioWeight = 0,
-							observerRewardRatioWeight = 0,
-							compositeWeight = 0,
-							normalizedCompositeWeight = 0,
-						},
+		it("should create a new epoch for the given timestamp if all previous epochs have been distributed", function()
+			_G.Epochs = {}
+			_G.GatewayRegistry = {
+				["test-this-is-valid-arweave-wallet-address-1"] = {
+					operatorStake = gar.getSettings().operators.minStake,
+					totalDelegatedStake = 0,
+					vaults = {},
+					delegates = {},
+					startTimestamp = 0,
+					stats = {
+						prescribedEpochCount = 0,
+						observedEpochCount = 0,
+						totalEpochCount = 0,
+						passedEpochCount = 0,
+						failedEpochCount = 0,
+						failedConsecutiveEpochs = 0,
+						passedConsecutiveEpochs = 0,
 					},
-					-- not eligible for rewards as it is leaving, so it should not be included in the eligible gateways count
-					["test-this-is-valid-arweave-wallet-address-2"] = {
-						operatorStake = gar.getSettings().operators.minStake,
-						totalDelegatedStake = 0,
-						vaults = {},
-						delegates = {},
-						startTimestamp = 0,
-						stats = {
-							prescribedEpochCount = 0,
-							observedEpochCount = 0,
-							totalEpochCount = 0,
-							passedEpochCount = 0,
-							failedEpochCount = 0,
-							failedConsecutiveEpochs = 0,
-							passedConsecutiveEpochs = 0,
-						},
-						settings = testSettings,
-						status = "leaving",
-						observerAddress = "test-this-is-valid-arweave-wallet-address-1",
-						weights = {
-							stakeWeight = 0,
-							tenureWeight = 0,
-							gatewayRewardRatioWeight = 0,
-							observerRewardRatioWeight = 0,
-							compositeWeight = 0,
-							normalizedCompositeWeight = 0,
-						},
+					settings = testSettings,
+					status = "joined",
+					observerAddress = "test-this-is-valid-arweave-wallet-address-1",
+					weights = {
+						stakeWeight = 0,
+						tenureWeight = 0,
+						gatewayRewardRatioWeight = 0,
+						observerRewardRatioWeight = 0,
+						compositeWeight = 0,
+						normalizedCompositeWeight = 0,
 					},
-				}
-				local settings = epochs.getSettings()
-				local epochIndex = 1
-				local epochStartTimestamp = settings.epochZeroStartTimestamp + settings.durationMs
-				local timestamp = epochStartTimestamp
-				local epochEndTimestamp = epochStartTimestamp + settings.durationMs
-				local epochDistributionTimestamp = epochEndTimestamp + settings.distributionDelayMs
-				local epochStartBlockHeight = 0
-				local expectedEligibleRewards = math.floor(protocolBalance * constants.minimumRewardRate)
-				local expectedTotalGatewayReward = math.floor(expectedEligibleRewards * 0.90)
-				local expectedTotalObserverReward = math.floor(expectedEligibleRewards * 0.10)
-				local expectedPerGatewayReward = math.floor(expectedTotalGatewayReward / 1) -- only one gateway in the registry
-				local expectedPerObserverReward = math.floor(expectedTotalObserverReward / 1) -- only one prescribed observer
-				local expectation = {
-					startTimestamp = epochStartTimestamp,
-					endTimestamp = epochEndTimestamp,
-					epochIndex = epochIndex,
-					startHeight = 0,
-					distributionTimestamp = epochDistributionTimestamp,
-					observations = {
-						failureSummaries = {},
-						reports = {},
+				},
+				-- not eligible for rewards as it is leaving, so it should not be included in the eligible gateways count
+				["test-this-is-valid-arweave-wallet-address-2"] = {
+					operatorStake = gar.getSettings().operators.minStake,
+					totalDelegatedStake = 0,
+					vaults = {},
+					delegates = {},
+					startTimestamp = 0,
+					stats = {
+						prescribedEpochCount = 0,
+						observedEpochCount = 0,
+						totalEpochCount = 0,
+						passedEpochCount = 0,
+						failedEpochCount = 0,
+						failedConsecutiveEpochs = 0,
+						passedConsecutiveEpochs = 0,
 					},
-					prescribedObservers = {
-						["test-this-is-valid-arweave-wallet-address-1"] = "test-this-is-valid-arweave-wallet-address-1",
+					settings = testSettings,
+					status = "leaving",
+					observerAddress = "test-this-is-valid-arweave-wallet-address-1",
+					weights = {
+						stakeWeight = 0,
+						tenureWeight = 0,
+						gatewayRewardRatioWeight = 0,
+						observerRewardRatioWeight = 0,
+						compositeWeight = 0,
+						normalizedCompositeWeight = 0,
 					},
-					prescribedNames = {},
-					distributions = {
-						totalEligibleGateways = 1,
-						totalEligibleRewards = expectedEligibleRewards,
-						totalEligibleGatewayReward = expectedTotalGatewayReward,
-						totalEligibleObserverReward = expectedTotalObserverReward,
-						rewards = {
-							eligible = {
-								["test-this-is-valid-arweave-wallet-address-1"] = {
-									operatorReward = expectedPerGatewayReward + expectedPerObserverReward,
-									delegateRewards = {}, -- no delegates
-								},
+				},
+			}
+			local settings = epochs.getSettings()
+			local epochIndex = 1
+			local epochStartTimestamp = settings.epochZeroStartTimestamp + settings.durationMs
+			local timestamp = epochStartTimestamp
+			local epochEndTimestamp = epochStartTimestamp + settings.durationMs
+			local epochDistributionTimestamp = epochEndTimestamp + settings.distributionDelayMs
+			local epochStartBlockHeight = 0
+			local expectedEligibleRewards = math.floor(protocolBalance * constants.minimumRewardRate)
+			local expectedTotalGatewayReward = math.floor(expectedEligibleRewards * 0.90)
+			local expectedTotalObserverReward = math.floor(expectedEligibleRewards * 0.10)
+			local expectedPerGatewayReward = math.floor(expectedTotalGatewayReward / 1) -- only one gateway in the registry
+			local expectedPerObserverReward = math.floor(expectedTotalObserverReward / 1) -- only one prescribed observer
+			local expectation = {
+				startTimestamp = epochStartTimestamp,
+				endTimestamp = epochEndTimestamp,
+				epochIndex = epochIndex,
+				startHeight = 0,
+				distributionTimestamp = epochDistributionTimestamp,
+				observations = {
+					failureSummaries = {},
+					reports = {},
+				},
+				prescribedObservers = {
+					["test-this-is-valid-arweave-wallet-address-1"] = "test-this-is-valid-arweave-wallet-address-1",
+				},
+				prescribedNames = {},
+				distributions = {
+					totalEligibleGateways = 1,
+					totalEligibleRewards = expectedEligibleRewards,
+					totalEligibleGatewayReward = expectedTotalGatewayReward,
+					totalEligibleObserverReward = expectedTotalObserverReward,
+					rewards = {
+						eligible = {
+							["test-this-is-valid-arweave-wallet-address-1"] = {
+								operatorReward = expectedPerGatewayReward + expectedPerObserverReward,
+								delegateRewards = {}, -- no delegates
 							},
 						},
 					},
-				}
-				local result = epochs.createEpoch(timestamp, epochStartBlockHeight, hashchain)
-				assert.are.same(expectation, result)
-				assert.are.same(expectation, epochs.getEpoch(epochIndex))
-				-- confirm the gateway weights were updated
-				assert.are.same({
-					stakeWeight = 1,
-					tenureWeight = 4,
-					gatewayRewardRatioWeight = 1,
-					observerRewardRatioWeight = 1,
-					compositeWeight = 4,
-					normalizedCompositeWeight = 1,
-				}, _G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"].weights)
-				-- confirm the leaving gateway weights were not updated
-				assert.are.same({
-					stakeWeight = 0,
-					tenureWeight = 0,
-					gatewayRewardRatioWeight = 0,
-					observerRewardRatioWeight = 0,
-					compositeWeight = 0,
-					normalizedCompositeWeight = 0,
-				}, _G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-2"].weights)
-			end
-		)
+				},
+			}
+			local result = epochs.createEpoch(timestamp, epochStartBlockHeight, hashchain)
+			assert.are.same(expectation, result)
+			assert.are.same(expectation, epochs.getEpoch(epochIndex))
+			-- confirm the gateway weights were updated
+			assert.are.same({
+				stakeWeight = 1,
+				tenureWeight = 4,
+				gatewayRewardRatioWeight = 1,
+				observerRewardRatioWeight = 1,
+				compositeWeight = 4,
+				normalizedCompositeWeight = 1,
+			}, _G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-1"].weights)
+			-- confirm the leaving gateway weights were not updated
+			assert.are.same({
+				stakeWeight = 0,
+				tenureWeight = 0,
+				gatewayRewardRatioWeight = 0,
+				observerRewardRatioWeight = 0,
+				compositeWeight = 0,
+				normalizedCompositeWeight = 0,
+			}, _G.GatewayRegistry["test-this-is-valid-arweave-wallet-address-2"].weights)
+		end)
 	end)
 
 	describe("distributeRewardsForEpoch", function()

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -461,7 +461,7 @@ describe("epochs", function()
 		it(
 			"should create a new epoch for the given timestamp if there is no previous epoch that has not been distributed",
 			function()
-				_G.Epochs[0] = nil
+				_G.Epochs = {}
 				_G.GatewayRegistry = {
 					["test-this-is-valid-arweave-wallet-address-1"] = {
 						operatorStake = gar.getSettings().operators.minStake,

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -459,17 +459,9 @@ describe("epochs", function()
 
 	describe("createEpoch", function()
 		it(
-			"should create a new epoch for the given timestamp once distributions for the last epoch have occurred",
+			"should create a new epoch for the given timestamp if there is no previous epoch that has not been distributed",
 			function()
-				_G.Epochs[0].distributions = {
-					totalEligibleRewards = 0,
-					totalDistributedRewards = 0,
-					distributedTimestamp = 0, -- it has a distribution timestamp
-					rewards = {
-						eligible = {},
-						distributed = {},
-					},
-				}
+				_G.Epochs[0] = nil
 				_G.GatewayRegistry = {
 					["test-this-is-valid-arweave-wallet-address-1"] = {
 						operatorStake = gar.getSettings().operators.minStake,

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -600,8 +600,9 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 	--- The epoch was already distributed
 	--- @cast epoch DistributedEpoch
 	if epoch.distributions.distributedTimestamp then
-		print("Rewards already distributed for epoch: " .. epochIndex)
-		return -- silently return
+		print("Rewards already distributed for epoch. Epoch will be removed from the epoch registry: " .. epochIndex)
+		Epochs[epochIndex] = nil
+		return epoch
 	end
 
 	--- Epoch is prescribed, but not eligible for distribution
@@ -609,7 +610,7 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 	if currentTimestamp < epoch.distributionTimestamp then
 		-- silently ignore - Distribution can only occur after the epoch has ended
 		print("Distribution can only occur after the epoch has ended")
-		return
+		return nil
 	end
 
 	local eligibleGatewaysForEpoch = epoch.distributions.rewards.eligible or {}

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -366,8 +366,8 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 	local epochIndex = epochs.getEpochIndexForTimestamp(timestamp)
 	if epochs.getEpoch(epochIndex) then
 		-- silently return
-		print("Epoch already exists for index. Returning existing epoch: " .. epochIndex)
-		return nil
+		print("Epoch already exists for index: " .. epochIndex)
+		return nil -- do not return the existing epoch to prevent sending redundant epoch-created-notices
 	end
 
 	local prevEpochIndex = epochIndex - 1
@@ -587,7 +587,7 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 	local epochIndex = epochs.getEpochIndexForTimestamp(currentTimestamp - epochs.getSettings().durationMs) -- go back to previous epoch
 	local epoch = epochs.getEpoch(epochIndex)
 	if not epoch then
-		-- silently return
+		-- TODO: consider throwing an error here instead of silently returning, as this is a critical error and should be fixed
 		print("Unable to distribute rewards for epoch. Epoch not found: " .. epochIndex)
 		return
 	end

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -378,15 +378,8 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 
 	local prevEpochIndex = epochIndex - 1
 	local prevEpoch = epochs.getEpoch(prevEpochIndex)
-	-- if the previous epoch is not the genesis epoch and we have not distributed rewards, we cannot create a new epoch
-	if
-		prevEpochIndex > 0 -- only validate distributions occurred if previous epoch is not the genesis epoch
-		and (
-			prevEpoch.distributions == nil
-			or prevEpoch.distributions.distributedTimestamp == nil
-			or timestamp < prevEpoch.distributions.distributedTimestamp
-		)
-	then
+	-- if there is a previous epoch and it has not been distributed, we cannot create a new epoch. once the epoch has been distributed, it will be removed from the epoch registry
+	if prevEpoch and (not prevEpoch.distributions or not prevEpoch.distributions.distributedTimestamp) then
 		-- silently return
 		print(
 			"Distributions have not occurred for the previous epoch. A new epoch will not be created until those are complete: "


### PR DESCRIPTION
…ng new one

A bit more cleanup around handling old epochs. A slight modification for the logic around creating a new epoch, as well is returning `nil` for epochs that do not exist as opposed to an empty object.