### PR TITLE
fix(epochs): do not return previously distributed epoch if already di…

### DIFF
--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -587,17 +587,15 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 	local epochIndex = epochs.getEpochIndexForTimestamp(currentTimestamp - epochs.getSettings().durationMs) -- go back to previous epoch
 	local epoch = epochs.getEpoch(epochIndex)
 	if not epoch then
-		-- TODO: consider throwing an error here instead of silently returning, as this is a critical error and should be fixed
-		print("Unable to distribute rewards for epoch. Epoch not found: " .. epochIndex)
-		return
+		error("Unable to distribute rewards for epoch. Epoch does not exist in epoch registry: " .. epochIndex)
 	end
 
-	--- The epoch was already distributed
+	--- The epoch was already distributed and should be cleaned up
 	--- @cast epoch DistributedEpoch
 	if epoch.distributions.distributedTimestamp then
 		print("Rewards already distributed for epoch. Epoch will be removed from the epoch registry: " .. epochIndex)
 		Epochs[epochIndex] = nil
-		return epoch
+		return nil -- do not return the epoch as it has already been distributed, and we do not want to send redundant epoch-distributed-notices
 	end
 
 	--- Epoch is prescribed, but not eligible for distribution

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -116,7 +116,8 @@ end
 --- @param epochIndex number The epoch index
 --- @return table<WalletAddress, WalletAddress> # The prescribed observers for the epoch
 function epochs.getPrescribedObserversForEpoch(epochIndex)
-	return epochs.getEpoch(epochIndex).prescribedObservers or {}
+	local epoch = epochs.getEpoch(epochIndex)
+	return epoch and epoch.prescribedObservers or {}
 end
 
 --- Get prescribed observers with weights for epoch
@@ -181,35 +182,40 @@ end
 --- @param epochIndex number The epoch index
 --- @return Observations # The observations for the epoch
 function epochs.getObservationsForEpoch(epochIndex)
-	return epochs.getEpoch(epochIndex).observations or {}
+	local epoch = epochs.getEpoch(epochIndex)
+	return epoch and epoch.observations or {}
 end
 
 --- Gets the distributions for an epoch
 --- @param epochIndex number The epoch index
 --- @return DistributedEpochDistribution | PrescribedEpochDistribution # The distributions for the epoch
 function epochs.getDistributionsForEpoch(epochIndex)
-	return epochs.getEpoch(epochIndex).distributions or {}
+	local epoch = epochs.getEpoch(epochIndex)
+	return epoch and epoch.distributions or {}
 end
 
 --- Gets the prescribed names for an epoch
 --- @param epochIndex number The epoch index
 --- @return string[] # The prescribed names for the epoch
 function epochs.getPrescribedNamesForEpoch(epochIndex)
-	return epochs.getEpoch(epochIndex).prescribedNames or {}
+	local epoch = epochs.getEpoch(epochIndex)
+	return epoch and epoch.prescribedNames or {}
 end
 
 --- Gets the reports for an epoch
 --- @param epochIndex number The epoch index
 --- @return table<WalletAddress, TransactionId> # The reports for the epoch
 function epochs.getReportsForEpoch(epochIndex)
-	return epochs.getEpoch(epochIndex).observations.reports or {}
+	local epoch = epochs.getEpoch(epochIndex)
+	return epoch and epoch.observations.reports or {}
 end
 
 --- Gets the distribution for an epoch
 --- @param epochIndex number The epoch index
 --- @return DistributedEpochDistribution | PrescribedEpochDistribution # The distribution for the epoch
 function epochs.getDistributionForEpoch(epochIndex)
-	return epochs.getEpoch(epochIndex).distributions or {}
+	local epoch = epochs.getEpoch(epochIndex)
+	return epoch and epoch.distributions or {}
 end
 
 --- Computes the prescribed names for an epoch
@@ -374,12 +380,12 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 	local prevEpoch = epochs.getEpoch(prevEpochIndex)
 	-- if there is a previous epoch and it has not been distributed, we cannot create a new epoch. once the epoch has been distributed, it will be removed from the epoch registry
 	if prevEpoch and not prevEpoch.distributions.distributedTimestamp then
-		-- silently return
+		-- TODO: consider throwing an error here instead of silently returning
 		print(
 			"Distributions have not occurred for the previous epoch. A new epoch cannot be created until distribution for the previous epoch is complete: "
 				.. prevEpochIndex
 		)
-		return
+		return nil
 	end
 
 	local epochStartTimestamp, epochEndTimestamp, epochDistributionTimestamp =
@@ -587,7 +593,9 @@ function epochs.distributeRewardsForEpoch(currentTimestamp)
 	local epochIndex = epochs.getEpochIndexForTimestamp(currentTimestamp - epochs.getSettings().durationMs) -- go back to previous epoch
 	local epoch = epochs.getEpoch(epochIndex)
 	if not epoch then
-		error("Unable to distribute rewards for epoch. Epoch does not exist in epoch registry: " .. epochIndex)
+		-- TODO: consider throwing an error here instead of silently returning, as this is a critical error and should be fixed
+		print("Unable to distribute rewards for epoch. Epoch not found: " .. epochIndex)
+		return nil
 	end
 
 	--- The epoch was already distributed and should be cleaned up

--- a/src/main.lua
+++ b/src/main.lua
@@ -2002,8 +2002,10 @@ addEventingHandler(ActionMap.Epoch, utils.hasMatchingTag("Action", ActionMap.Epo
 	local epochIndex = msg.Tags["Epoch-Index"] and tonumber(msg.Tags["Epoch-Index"])
 		or epochs.getEpochIndexForTimestamp(msg.Timestamp)
 	local epoch = epochs.getEpoch(epochIndex)
-	-- populate the prescribed observers with weights for the epoch, this helps improve DX of downstream apps
-	epoch.prescribedObservers = epochs.getPrescribedObserversWithWeightsForEpoch(epochIndex)
+	if epoch then
+		-- populate the prescribed observers with weights for the epoch, this helps improve DX of downstream apps
+		epoch.prescribedObservers = epochs.getPrescribedObserversWithWeightsForEpoch(epochIndex)
+	end
 	Send(msg, { Target = msg.From, Action = "Epoch-Notice", Data = json.encode(epoch) })
 end)
 

--- a/tests/tick.test.mjs
+++ b/tests/tick.test.mjs
@@ -324,7 +324,7 @@ describe('Tick', async () => {
    * - validate the rewards were distributed correctly
    * - send epoch distribution notice containing full epoch data
    */
-  it('should distribute rewards to gateways and delegates and send an epoch distribution notice', async () => {
+  it('should distribute rewards to gateways and delegates, send an epoch distribution notice and remove the epoch from the epoch registry', async () => {
     // give balance to gateway
     const initialMemory = await transfer({
       recipient: STUB_ADDRESS,
@@ -597,6 +597,14 @@ describe('Tick', async () => {
         address: delegateAddress,
       },
     ]);
+
+    // assert the distributed epoch was removed from the epoch registry
+    const epoch = await getEpoch({
+      memory: distributionTick.memory,
+      timestamp: distributionTimestamp,
+      epochIndex: 0,
+    });
+    assert.equal(epoch, undefined);
     sharedMemory = distributionTick.memory;
   });
 


### PR DESCRIPTION
…stributed

This should have been done in previous PR. There are side effects when distributing epochs (event data, and notices) so we DO NOT want to return them if they were already distributed. We do want to remove them from the registry if they exist and have been distributed, however.