### PR TITLE
chore(PE-7555): fix arns pruning bug, standardize logic for pruning

### DIFF
--- a/src/arns.lua
+++ b/src/arns.lua
@@ -980,7 +980,7 @@ function arns.pruneRecords(currentTimestamp, lastGracePeriodEntryEndTimestamp)
 	-- identify any records that are leases and that have expired, account for a two week grace period in seconds
 	NextRecordsPruneTimestamp = nil
 
-	for name, record in pairs(arns.getRecords()) do
+	for name, record in pairs(arns.getRecordsUnsafe()) do
 		if arns.recordExpired(record, currentTimestamp) then
 			prunedRecords[name] = record
 			NameRegistry.records[name] = nil

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -150,7 +150,6 @@ function arns.buyRecord(name, purchaseType, years, from, timestamp, processId, m
 	-- Transfer tokens to the protocol balance
 	balances.increaseBalance(ao.id, rewardForProtocol)
 	arns.addRecord(name, newRecord)
-
 	demand.tallyNamePurchase(totalFee)
 	return {
 		record = arns.getRecord(name),
@@ -1075,7 +1074,10 @@ end
 
 --- @param timestamp Timestamp
 function arns.scheduleNextRecordsPrune(timestamp)
+	local currentNextPruneRecordsTimestamp = NextRecordsPruneTimestamp or 0
+	print("Current next prune records timestamp: " .. currentNextPruneRecordsTimestamp)
 	NextRecordsPruneTimestamp = math.min(NextRecordsPruneTimestamp or timestamp, timestamp)
+	print("Updated next prune records timestamp to " .. NextRecordsPruneTimestamp)
 end
 
 --- @param timestamp Timestamp

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -987,7 +987,7 @@ function arns.pruneRecords(currentTimestamp, lastGracePeriodEntryEndTimestamp)
 		elseif arns.recordInGracePeriod(record, currentTimestamp) then
 			if record.endTimestamp > lastGracePeriodEntryEndTimestamp then
 				print(
-					"Adding record " .. name .. " to new grace period records because it has entered it's grace period"
+					"Adding record " .. name .. " to new grace period records because it has entered its grace period"
 				)
 				newGracePeriodRecords[name] = record
 			end

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -53,9 +53,9 @@ constants.ARNS_NAME_DOES_NOT_EXIST_MESSAGE = "Name not found in the ArNS Registr
 constants.UNDERNAME_LEASE_FEE_PERCENTAGE = 0.001
 constants.UNDERNAME_PERMABUY_FEE_PERCENTAGE = 0.005
 constants.PRIMARY_NAME_REQUEST_COST = constants.ARIOToMARIO(10) -- 10 ARIO
-constants.gracePeriodMs = constants.defaultEpochDurationMs * 14 -- 14 epochs
+constants.gracePeriodMs = constants.twoWeeksMs
 constants.maxLeaseLengthYears = 5
-constants.returnedNamePeriod = constants.defaultEpochDurationMs * 14 -- 14 epochs
+constants.returnedNamePeriod = constants.twoWeeksMs
 constants.returnedNameMaxMultiplier = 50 -- Freshly returned names will have a multiplier of 50x
 
 constants.ARNS_DISCOUNT_PERCENTAGE = 0.2

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -782,8 +782,9 @@ function epochs.pruneEpochs(timestamp)
 		return prunedEpochIndexes
 	end
 
-	--- Reset the next pruning timestamp
+	-- reset the next prune timestamp, below will populate it with the next prune timestamp minimum
 	NextEpochsPruneTimestamp = nil
+
 	local currentEpochIndex = epochs.getEpochIndexForTimestamp(timestamp)
 	local cutoffEpochIndex = currentEpochIndex - 1 -- keep the two most recent epochs, on distribution the previous epoch will remove itself
 	local unsafeEpochs = epochs.getEpochsUnsafe()
@@ -795,13 +796,15 @@ function epochs.pruneEpochs(timestamp)
 			Epochs[nextEpochIndex] = nil
 		else
 			local _, endTimestamp = epochs.getEpochTimestampsForIndex(nextEpochIndex)
-			if endTimestamp >= timestamp then
-				NextEpochsPruneTimestamp = math.min(NextEpochsPruneTimestamp or endTimestamp, endTimestamp)
-			end
+			epochs.scheduleNextEpochsPrune(endTimestamp)
 		end
 		nextEpochIndex = next(unsafeEpochs, nextEpochIndex)
 	end
 	return prunedEpochIndexes
+end
+
+function epochs.scheduleNextEpochsPrune(timestamp)
+	NextEpochsPruneTimestamp = math.min(NextEpochsPruneTimestamp or timestamp, timestamp)
 end
 
 function epochs.nextEpochsPruneTimestamp()

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -796,7 +796,9 @@ function epochs.pruneEpochs(timestamp)
 			Epochs[nextEpochIndex] = nil
 		else
 			local _, endTimestamp = epochs.getEpochTimestampsForIndex(nextEpochIndex)
-			epochs.scheduleNextEpochsPrune(endTimestamp)
+			if endTimestamp >= timestamp then
+				epochs.scheduleNextEpochsPrune(endTimestamp)
+			end
 		end
 		nextEpochIndex = next(unsafeEpochs, nextEpochIndex)
 	end

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -1007,7 +1007,7 @@ function gar.pruneGateways(currentTimestamp, msgId)
 					result.gatewayStakeReturned = result.gatewayStakeReturned + vault.balance
 				else
 					-- find the next prune timestamp
-					minNextEndTimestamp = math.min(minNextEndTimestamp or vault.endTimestamp, vault.endTimestamp)
+					gar.scheduleNextGatewaysPruning(vault.endTimestamp)
 					gatewayObjectTallies.numGatewayVaults = gatewayObjectTallies.numGatewayVaults + 1
 				end
 			end
@@ -1022,7 +1022,7 @@ function gar.pruneGateways(currentTimestamp, msgId)
 						result.delegateStakeReturned = result.delegateStakeReturned + vault.balance
 					else
 						-- find the next prune timestamp
-						minNextEndTimestamp = math.min(minNextEndTimestamp or vault.endTimestamp, vault.endTimestamp)
+						gar.scheduleNextGatewaysPruning(gateway.endTimestamp)
 						gatewayObjectTallies.numDelegateVaults = gatewayObjectTallies.numDelegateVaults + 1
 					end
 				end
@@ -1077,7 +1077,7 @@ function gar.pruneGateways(currentTimestamp, msgId)
 							table.insert(result.prunedGateways, gatewayAddress)
 						else
 							-- find the next prune timestamp
-							gar.scheduleNextGatewaysPruning(minNextEndTimestamp)
+							gar.scheduleNextGatewaysPruning(gateway.endTimestamp)
 						end
 					end
 				end

--- a/src/primary_names.lua
+++ b/src/primary_names.lua
@@ -365,22 +365,17 @@ function primaryNames.prunePrimaryNameRequests(timestamp)
 		return prunedNameRequests
 	end
 
-	local minNextEndTimestamp
+	-- reset the next prune timestamp, below will populate it with the next prune timestamp minimum
+	NextPrimaryNamesPruneTimestamp = nil
+
 	for initiator, request in pairs(primaryNames.getUnsafePrimaryNameRequests()) do
 		if request.endTimestamp <= timestamp then
 			PrimaryNames.requests[initiator] = nil
 			prunedNameRequests[initiator] = request
 		else
-			minNextEndTimestamp = math.min(minNextEndTimestamp or request.endTimestamp, request.endTimestamp)
+			primaryNames.scheduleNextPrimaryNamesPruning(request.endTimestamp)
 		end
 	end
-
-	-- Reset the pruning timestamp
-	NextPrimaryNamesPruneTimestamp = nil
-	if minNextEndTimestamp then
-		primaryNames.scheduleNextPrimaryNamesPruning(minNextEndTimestamp)
-	end
-
 	return prunedNameRequests
 end
 

--- a/src/vaults.lua
+++ b/src/vaults.lua
@@ -233,8 +233,10 @@ function vaults.pruneVaults(currentTimestamp)
 
 	local allVaults = vaults.getVaults()
 	local prunedVaults = {}
-	--- @type Timestamp|nil
-	local minNextEndTimestamp
+
+	-- reset the next prune timestamp, below will populate it with the next prune timestamp minimum
+	NextBalanceVaultsPruneTimestamp = nil
+
 	for owner, ownersVaults in pairs(allVaults) do
 		for id, nestedVault in pairs(ownersVaults) do
 			if currentTimestamp >= nestedVault.endTimestamp then
@@ -242,19 +244,10 @@ function vaults.pruneVaults(currentTimestamp)
 				ownersVaults[id] = nil
 				prunedVaults[id] = nestedVault
 			else
-				--- find the next prune timestamp
-				minNextEndTimestamp =
-					math.min(minNextEndTimestamp or nestedVault.endTimestamp, nestedVault.endTimestamp)
+				vaults.scheduleNextVaultsPruning(nestedVault.endTimestamp)
 			end
 		end
 	end
-
-	-- Reset the pruning timestamp
-	NextBalanceVaultsPruneTimestamp = nil
-	if minNextEndTimestamp then
-		vaults.scheduleNextVaultsPruning(minNextEndTimestamp)
-	end
-
 	-- set the vaults to the updated vaults
 	Vaults = allVaults
 	return prunedVaults

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -67,7 +67,7 @@ export function assertNoResultError(result) {
     (tag) => tag.name === 'Error',
   );
   assert.strictEqual(errorTag, undefined);
-  // assertValidSupplyEventData(result);
+  assertValidSupplyEventData(result);
 }
 
 export function parseEventsFromResult(result) {

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -67,7 +67,7 @@ export function assertNoResultError(result) {
     (tag) => tag.name === 'Error',
   );
   assert.strictEqual(errorTag, undefined);
-  assertValidSupplyEventData(result);
+  // assertValidSupplyEventData(result);
 }
 
 export function parseEventsFromResult(result) {
@@ -863,6 +863,53 @@ export const tick = async ({
     memory: tickResult.Memory,
     result: tickResult,
   };
+};
+
+export const getInfo = async ({ memory, timestamp }) => {
+  const nameResult = await handle({
+    options: {
+      Tags: [{ name: 'Action', value: 'Info' }],
+      Timestamp: timestamp,
+    },
+    memory,
+  });
+  console.log(nameResult);
+  assertNoResultError(nameResult);
+  return {
+    memory: nameResult.Memory,
+    result: nameResult,
+  };
+};
+
+export const getRecord = async ({
+  memory,
+  timestamp = STUB_TIMESTAMP,
+  name,
+}) => {
+  const nameResult = await handle({
+    options: {
+      Tags: [
+        { name: 'Action', value: 'Record' },
+        { name: 'Name', value: name },
+      ],
+      Timestamp: timestamp,
+    },
+    memory,
+  });
+  assertNoResultError(nameResult);
+  return JSON.parse(nameResult.Messages[0].Data);
+};
+
+export const getPruningTimestamps = async ({ memory, timestamp }) => {
+  const nameResult = await handle({
+    options: {
+      Tags: [{ name: 'Action', value: 'Pruning-Timestamps' }],
+      Timestamp: timestamp,
+    },
+    memory,
+  });
+  assertNoResultError(nameResult);
+  return JSON.parse(nameResult.Messages[0].Data);
 };
 
 export const getEpoch = async ({

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -873,7 +873,6 @@ export const getInfo = async ({ memory, timestamp }) => {
     },
     memory,
   });
-  console.log(nameResult);
   assertNoResultError(nameResult);
   return {
     memory: nameResult.Memory,

--- a/tests/prune.test.mjs
+++ b/tests/prune.test.mjs
@@ -86,16 +86,16 @@ describe('ARNS Record Pruning', () => {
     sharedMemory = infoResult.memory;
 
     // parse the output event data to validate the name was pruned
-    // const [eventOutput] = parseEventsFromResult(infoResult.result);
-    // const prunedRecordsCount = eventOutput['Pruned-Records-Count'];
-    // assert.equal(prunedRecordsCount, 1, 'Expected 1 record to be pruned');
-    // const prunedRecords = eventOutput['Pruned-Records'];
-    // assert.equal(prunedRecords.length, 1, 'Expected 1 record to be pruned');
-    // assert.equal(
-    //   prunedRecords[0],
-    //   names[0],
-    //   'Expected the first record to be pruned',
-    // );
+    const [eventOutput] = parseEventsFromResult(infoResult.result);
+    const prunedRecordsCount = eventOutput['Pruned-Records-Count'];
+    assert.equal(prunedRecordsCount, 1, 'Expected 1 record to be pruned');
+    const prunedRecords = eventOutput['Pruned-Records'];
+    assert.equal(prunedRecords.length, 1, 'Expected 1 record to be pruned');
+    assert.equal(
+      prunedRecords[0],
+      names[0],
+      'Expected the first record to be pruned',
+    );
 
     // check the pruning timestamp is updated after the tick
     const { records: updatedRecordsPruningTimestamp } =

--- a/tests/prune.test.mjs
+++ b/tests/prune.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * Test suite for ARNS record pruning functionality
+ *
+ * The following tests share a memory buffer and validate:
+ *
+ * - Purchase 5 records as leases with different expiration years
+ * - Validate the initial global pruning timestamp is set to the lowest records prune timestamp
+ * - Validate the records exist in state until their grace period ends
+ * - Validate a non-tick, write interaction (that updates the array buffer) properly triggers the pruning
+ * - Validate event data is emitted when a record enters its grace period, and when it is pruned
+ * - Validate records are pruned after the grace period ends
+ * - Validate the global pruning timestamp is updated to the next records prune timestamp
+ */
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  getRecord,
+  startMemory,
+  buyRecord,
+  getPruningTimestamps,
+  tick,
+  getInfo,
+  parseEventsFromResult,
+} from './helpers.mjs';
+
+const STUB_TIMESTAMP = 1706814747000; // Jan 1 2024
+const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+const twoWeeksMs = 14 * 24 * 60 * 60 * 1000;
+
+describe('ARNS Record Pruning', () => {
+  let sharedMemory = startMemory;
+
+  it('should prune expired records after grace period', async () => {
+    // Purchase 5 records with different expiration years
+    const names = ['name1', 'name2', 'name3', 'name4', 'name5'];
+    const years = [1, 2, 3, 4, 5];
+
+    for (let i = 0; i < names.length; i++) {
+      const purchase = await buyRecord({
+        memory: sharedMemory,
+        timestamp: STUB_TIMESTAMP,
+        name: names[i],
+        years: years[i],
+        type: 'lease',
+      });
+      sharedMemory = purchase.memory;
+    }
+
+    // validate the pruning timestamp is the minimum of all the timestamps + 2 week grace period
+    const { records: recordsPruningTimestamp } = await getPruningTimestamps({
+      memory: sharedMemory,
+      timestamp: STUB_TIMESTAMP,
+    });
+
+    const expectedNextRecordsPruneTimestamp = STUB_TIMESTAMP + oneYearMs;
+    assert.equal(
+      recordsPruningTimestamp,
+      expectedNextRecordsPruneTimestamp,
+      `Expected pruning timestamp to be the minimum of existing record endTimestamps. Actual: ${new Date(recordsPruningTimestamp).toLocaleString()}. Expected: ${new Date(expectedNextRecordsPruneTimestamp).toLocaleString()}`,
+    );
+
+    // validate the record is reported event data includes in grace period records once record expires
+    const gracePeriodStartInfoResult = await getInfo({
+      memory: sharedMemory,
+      timestamp: expectedNextRecordsPruneTimestamp + 1,
+    });
+    const [gracePeriodStartEvent] = parseEventsFromResult(
+      gracePeriodStartInfoResult.result,
+    );
+    assert.equal(
+      gracePeriodStartEvent['New-Grace-Period-Records-Count'],
+      1,
+      'Expected 1 record to be marked as in grace period',
+    );
+    assert.deepEqual(gracePeriodStartEvent['New-Grace-Period-Records'], [
+      names[0],
+    ]);
+    sharedMemory = gracePeriodStartInfoResult.memory;
+
+    // send an info request to trigger the pruning when the grace period ends
+    const actualPruneTimestamp = expectedNextRecordsPruneTimestamp + twoWeeksMs;
+    const infoResult = await getInfo({
+      memory: sharedMemory,
+      timestamp: actualPruneTimestamp,
+    });
+    sharedMemory = infoResult.memory;
+
+    // parse the output event data to validate the name was pruned
+    // const [eventOutput] = parseEventsFromResult(infoResult.result);
+    // const prunedRecordsCount = eventOutput['Pruned-Records-Count'];
+    // assert.equal(prunedRecordsCount, 1, 'Expected 1 record to be pruned');
+    // const prunedRecords = eventOutput['Pruned-Records'];
+    // assert.equal(prunedRecords.length, 1, 'Expected 1 record to be pruned');
+    // assert.equal(
+    //   prunedRecords[0],
+    //   names[0],
+    //   'Expected the first record to be pruned',
+    // );
+
+    // check the pruning timestamp is updated after the tick
+    const { records: updatedRecordsPruningTimestamp } =
+      await getPruningTimestamps({
+        memory: sharedMemory,
+        timestamp: actualPruneTimestamp,
+      });
+
+    // validate the pruning timestamp is updated to the next records prune timestamp
+    const newRecordsPruningTimestamp = STUB_TIMESTAMP + 2 * oneYearMs;
+    assert.equal(
+      updatedRecordsPruningTimestamp,
+      newRecordsPruningTimestamp,
+      `Expected pruning timestamp to be the minimum of existing record endTimestamps. Actual: ${new Date(recordsPruningTimestamp).toLocaleString()}. Expected: ${new Date(newRecordsPruningTimestamp).toLocaleString()}`,
+    );
+
+    // Record should be pruned after grace period
+    const postGraceRecord = await getRecord({
+      memory: sharedMemory,
+      name: names[0],
+      timestamp: actualPruneTimestamp + 1,
+    });
+
+    assert.equal(
+      postGraceRecord,
+      null,
+      `Record ${names[0]} should be pruned after grace period`,
+    );
+  });
+});


### PR DESCRIPTION
This bug delays the pruning of records that should be removed after their grace period ends. 


TLDR:
- we correctly remove records that are expired
- we correctly update the minimum `NextRecordsPruneTimestamp` for those in their grace period
- we use `minEndTimestamp` to track the lowest endTimestamp of all records that are NOT in their grace period or expired
- we INCORRECTLY `nil` out `NextRecordsPruneTimestamp` and then set it to the `minNextEndTimestamp` variable if it was set, **overwriting any minimum that should have been set by records in their grace period**

Here is the `pruneRecords` function with additional comments (IN CAPS) on where/why the bug occurs

```lua
--- Prunes records that have expired
--- @param currentTimestamp number The current timestamp
--- @param lastGracePeriodEntryEndTimestamp number The end timestamp of the last known record to have entered its grace period
--- @return table<string, Record> prunedRecords - the pruned records
--- @return table<string, Record> recordsInGracePeriod - the records that have entered their grace period
function arns.pruneRecords(currentTimestamp, lastGracePeriodEntryEndTimestamp)
	lastGracePeriodEntryEndTimestamp = lastGracePeriodEntryEndTimestamp or 0
	local prunedRecords = {}
	local newGracePeriodRecords = {}
       -- WHEN THE NextRecordsPruneTimestamp IS SET INCORRECTLY BELOW, WE DELAY THE PRUNING OF RECORDS THAT SHOULD HAVE BEEN REMOVED EARLIER
	if not NextRecordsPruneTimestamp or NextRecordsPruneTimestamp > currentTimestamp then
		return prunedRecords, newGracePeriodRecords
	end

	--- @type Timestamp|nil
	local minNextEndTimestamp -- THIS LEADS TO THE BUG

        for name, record in pairs(arns.getRecords()) do
		if arns.recordExpired(record, currentTimestamp) then
			prunedRecords[name] = record
			NameRegistry.records[name] = nil
		elseif arns.recordInGracePeriod(record, currentTimestamp) then
			if record.endTimestamp > lastGracePeriodEntryEndTimestamp then
				newGracePeriodRecords[name] = record
			end
                        --- WE UPDATE TO THE GRACE PERIOD CORRECTLY HERE, AND IF THE RECORD IS LAST ONE TRAVERSED, WE'RE ALL GOOD!
			arns.scheduleNextRecordsPrune(record.endTimestamp + constants.gracePeriodMs)
		elseif record.endTimestamp then
                        --- EVERY OTHER RECORD THAT IS NOT EXPIRED/IN GRACE PERIOD UPDATES THIS VALUE
                        --- IT WILL USUALLY BE GREATER THAN THE LOWEST DETERMINED BY THE GRACE PERIOD RECORDS ABOVE!
			minNextEndTimestamp = math.min(minNextEndTimestamp or record.endTimestamp, record.endTimestamp)
		end
	end

        -- WE NIL OUT THE GLOBAL & minNextEndTimestamp IS THE LOWEST ACTIVE RECORD END TIMESTAMP
        -- THIS CAUSES US TO SKIP OVER THE MINIMUM THAT SHOULD HAVE BEEN SET BY RECORDS IN THEIR GRACE PERIOD!
	NextRecordsPruneTimestamp = nil
	if minNextEndTimestamp then
		arns.scheduleNextRecordsPrune(minNextEndTimestamp)
	end
	return prunedRecords, newGracePeriodRecords
end
```

This pattern is true for all prunes, so they have been updated in this PR to avoid using the minEndTimestamp, nil out the global first, then run the iteration to identify the minimum prune timestamp.