### PR TITLE
chore(PE-7040): remove deprecated gateway attributes

### DIFF
--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -92,10 +92,6 @@ describe("epochs", function()
 					tenureWeight = 1,
 					gatewayPerformanceRatio = 1,
 					observerPerformanceRatio = 1,
-					-- TODO: remove these for backwards compatibility - after ar-io-sdk update, remove these
-					gatewayRewardRatioWeight = 1,
-					observerRewardRatioWeight = 1,
-					-- END TODO
 					compositeWeight = 1,
 					stake = gar.getSettings().operators.minStake,
 					startTimestamp = startTimestamp,

--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -2328,10 +2328,6 @@ describe("gar", function()
 			local gateway2Copy = utils.deepCopy(gateway2)
 			gateway2Copy.delegates = nil
 			gateway2Copy.vaults = nil
-			-- TODO: add gatewayRewardRatioWeight and observerRewardRatioWeight as gatewayPerformanceRatio and observerPerformanceRatio for backwards compatibility
-			gateway2Copy.weights.gatewayRewardRatioWeight = gateway2Copy.weights.gatewayPerformanceRatio or 0
-			gateway2Copy.weights.observerRewardRatioWeight = gateway2Copy.weights.observerPerformanceRatio or 0
-			-- END TODO
 			assert.are.same({
 				limit = 1,
 				sortBy = "startTimestamp",
@@ -2348,10 +2344,6 @@ describe("gar", function()
 			local gateway1Copy = utils.deepCopy(gateway1)
 			gateway1Copy.delegates = nil
 			gateway1Copy.vaults = nil
-			-- TODO: add gatewayRewardRatioWeight and observerRewardRatioWeight as gatewayPerformanceRatio and observerPerformanceRatio for backwards compatibility
-			gateway1Copy.weights.gatewayRewardRatioWeight = gateway1Copy.weights.gatewayPerformanceRatio or 0
-			gateway1Copy.weights.observerRewardRatioWeight = gateway1Copy.weights.observerPerformanceRatio or 0
-			-- END TODO
 			assert.are.same({
 				limit = 1,
 				sortBy = "startTimestamp",

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -138,10 +138,6 @@ function epochs.getPrescribedObserversWithWeightsForEpoch(epochIndex)
 				tenureWeight = gateway.weights.tenureWeight,
 				gatewayPerformanceRatio = gateway.weights.gatewayPerformanceRatio,
 				observerPerformanceRatio = gateway.weights.observerPerformanceRatio,
-				-- TODO: remove these for backwards compatibility - after ar-io-sdk update, remove these
-				gatewayRewardRatioWeight = gateway.weights.gatewayPerformanceRatio,
-				observerRewardRatioWeight = gateway.weights.observerPerformanceRatio,
-				-- END TODO
 				compositeWeight = gateway.weights.compositeWeight,
 				stake = gateway.operatorStake,
 				startTimestamp = gateway.startTimestamp,

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -1118,10 +1118,6 @@ function gar.getPaginatedGateways(cursor, limit, sortBy, sortOrder)
 	for address, gateway in pairs(gateways) do
 		--- @diagnostic disable-next-line: inject-field
 		gateway.gatewayAddress = address
-		-- TODO: inject these for backwards compatibility - after ar-io-sdk update, remove these
-		gateway.weights.gatewayRewardRatioWeight = gateway.weights.gatewayPerformanceRatio or 0
-		gateway.weights.observerRewardRatioWeight = gateway.weights.observerPerformanceRatio or 0
-		-- END TODO
 		-- remove delegates and vaults to avoid sending unbounded arrays, they can be fetched via getPaginatedDelegates and getPaginatedVaults
 		gateway.delegates = nil
 		gateway.vaults = nil

--- a/src/main.lua
+++ b/src/main.lua
@@ -1929,12 +1929,6 @@ end)
 
 addEventingHandler(ActionMap.Gateway, Handlers.utils.hasMatchingTag("Action", ActionMap.Gateway), function(msg)
 	local gateway = gar.getCompactGateway(msg.Tags.Address or msg.From)
-	-- TODO: inject these for backwards compatibility - after ar-io-sdk update, remove these
-	if gateway then
-		gateway.weights.gatewayRewardRatioWeight = gateway.weights.gatewayPerformanceRatio or 0
-		gateway.weights.observerRewardRatioWeight = gateway.weights.observerPerformanceRatio or 0
-	end
-	-- END TODO
 	Send(msg, {
 		Target = msg.From,
 		Action = "Gateway-Notice",
@@ -2670,30 +2664,6 @@ addEventingHandler("allPaginatedGatewayVaults", utils.hasMatchingTag("Action", "
 	local page = utils.parsePaginationTags(msg)
 	local result = gar.getPaginatedVaultsFromAllGateways(page.cursor, page.limit, page.sortBy, page.sortOrder)
 	Send(msg, { Target = msg.From, Action = "All-Gateway-Vaults-Notice", Data = json.encode(result) })
-end)
-
--- TODO: handler for posting epoch distribution notices (make sure to remove this once previous epochs are distributed)
-UpdateGateways = false
-addEventingHandler("updateGatewayAttributes", utils.hasMatchingTag("Action", "Update-Gateway-Attributes"), function()
-	if UpdateGateways then
-		return
-	end
-	--- iterate over all gateways and update their attributes
-	for _, gateway in pairs(gar.getGatewaysUnsafe()) do
-		if gateway.weights.gatewayRewardRatioWeight then
-			-- set the gatewayRewardShareRatio to gatewayPerformanceRatio
-			gateway.weights.gatewayPerformanceRatio = gateway.weights.gatewayRewardRatioWeight
-			-- set the gatewayRewardRatioWeight to observerRewardRatioWeight to nil
-			gateway.weights.gatewayRewardRatioWeight = nil
-		end
-		if gateway.weights.observerRewardRatioWeight then
-			-- set the observerRewardShareRatio to observerPerformanceRatio
-			gateway.weights.observerPerformanceRatio = gateway.weights.observerRewardRatioWeight
-			-- set the observerRewardRatioWeight to nil
-			gateway.weights.observerRewardRatioWeight = nil
-		end
-	end
-	UpdateGateways = true
 end)
 
 return process

--- a/tests/epochs.test.mjs
+++ b/tests/epochs.test.mjs
@@ -67,10 +67,6 @@ describe('epochs', () => {
             stakeWeight: 1,
             gatewayPerformanceRatio: 1,
             observerPerformanceRatio: 1,
-            // TODO: remove these for backwards compatibility - after ar-io-sdk update, remove these
-            gatewayRewardRatioWeight: 1,
-            observerRewardRatioWeight: 1,
-            // END TODO
             compositeWeight: 4,
             normalizedCompositeWeight: 1,
             tenureWeight: 4,
@@ -115,10 +111,6 @@ describe('epochs', () => {
           gatewayAddress: STUB_OPERATOR_ADDRESS,
           gatewayPerformanceRatio: 1,
           normalizedCompositeWeight: 1,
-          // TODO: remove these for backwards compatibility - after ar-io-sdk update, remove these
-          gatewayRewardRatioWeight: 1,
-          observerRewardRatioWeight: 1,
-          // END TODO
           observerAddress: STUB_ADDRESS,
           observerPerformanceRatio: 1,
           stakeWeight: 1,

--- a/tests/gar.test.mjs
+++ b/tests/gar.test.mjs
@@ -117,10 +117,6 @@ describe('GatewayRegistry', async () => {
           tenureWeight: 0,
           gatewayPerformanceRatio: 0,
           observerPerformanceRatio: 0,
-          // TODO: add gatewayRewardRatioWeight and observerRewardRatioWeight as gatewayPerformanceRatio and observerPerformanceRatio for backwards compatibility
-          gatewayRewardRatioWeight: 0,
-          observerRewardRatioWeight: 0,
-          // END TODO
           compositeWeight: 0,
           normalizedCompositeWeight: 0,
         },
@@ -194,10 +190,6 @@ describe('GatewayRegistry', async () => {
           tenureWeight: 0,
           gatewayPerformanceRatio: 0,
           observerPerformanceRatio: 0,
-          // TODO: add gatewayRewardRatioWeight and observerRewardRatioWeight as gatewayPerformanceRatio and observerPerformanceRatio for backwards compatibility
-          gatewayRewardRatioWeight: 0,
-          observerRewardRatioWeight: 0,
-          // END TODO
           compositeWeight: 0,
           normalizedCompositeWeight: 0,
         },

--- a/tests/handlers.test.mjs
+++ b/tests/handlers.test.mjs
@@ -24,7 +24,7 @@ describe('handlers', async () => {
     const defaultIndex = handlersList.indexOf('_default');
     const sanitizeIndex = handlersList.indexOf('sanitize');
     const pruneIndex = handlersList.indexOf('prune');
-    const expectedHandlerCount = 76; // this should be updated if more handlers are added
+    const expectedHandlerCount = 75; // this should be updated if more handlers are added
     assert.ok(evalIndex === 0);
     assert.ok(defaultIndex === 1);
     assert.ok(sanitizeIndex === 2);

--- a/tests/tick.test.mjs
+++ b/tests/tick.test.mjs
@@ -429,10 +429,6 @@ describe('Tick', async () => {
           stakeWeight: 3,
           gatewayPerformanceRatio: 1,
           observerPerformanceRatio: 1,
-          // TODO: remove these for backwards compatibility - after ar-io-sdk update, remove these
-          gatewayRewardRatioWeight: 1,
-          observerRewardRatioWeight: 1,
-          // END TODO
           compositeWeight: 12,
           normalizedCompositeWeight: 1,
           tenureWeight: 4,
@@ -584,10 +580,6 @@ describe('Tick', async () => {
         gatewayPerformanceRatio: 1,
         normalizedCompositeWeight: 1,
         observerPerformanceRatio: 1,
-        // TODO: add gatewayRewardRatioWeight and observerRewardRatioWeight as gatewayPerformanceRatio and observerPerformanceRatio for backwards compatibility
-        gatewayRewardRatioWeight: 1,
-        observerRewardRatioWeight: 1,
-        // END TODO
         stakeWeight: 5.5,
         tenureWeight: 4,
       },


### PR DESCRIPTION
SDK and Network-portal are updated to use the new values. We can stop storing them on the contract