### PR TITLE
fix(arns): fix arns stat issue

### DIFF
--- a/spec/arns_spec.lua
+++ b/spec/arns_spec.lua
@@ -1231,6 +1231,72 @@ describe("arns", function()
 		end)
 	end)
 
+	describe("getArNSStatsBetweenTimestamps", function()
+		it("should return the correct ArNS stats", function()
+			local currentTimestamp = constants.gracePeriodMs
+			local endTimestamp = currentTimestamp + 1000000
+			_G.NameRegistry = {
+				returned = {
+					["returned-record"] = {
+						name = "returned-record",
+						startTimestamp = currentTimestamp - 1,
+					},
+					-- this should not be counted as a returned name since it's expired
+					["expired-returned"] = {
+						name = "expired-returned",
+						startTimestamp = currentTimestamp - constants.returnedNamePeriod - 1,
+					},
+				},
+				reserved = {
+					["reserved-record"] = {
+						endTimestamp = 2000000000,
+					},
+					-- this should not be counted as a reserved name since it's expired
+					["expired-reserved"] = {
+						endTimestamp = 0,
+					},
+					["permabuy-reserved"] = {
+						target = "some-wallet-address",
+					},
+				},
+				records = {
+					["active-record"] = {
+						startTimestamp = 0,
+						type = "lease",
+						endTimestamp = endTimestamp * 2,
+					},
+					-- this should not be counted as an active name since it's expired
+					["expired-record"] = {
+						startTimestamp = 0,
+						type = "lease",
+						endTimestamp = 0,
+					},
+					-- this should not be counted as an active name since it starts after the current timestamp
+					["future-record"] = {
+						startTimestamp = currentTimestamp + 1,
+						type = "lease",
+						endTimestamp = endTimestamp * 2,
+					},
+					["permabuy-record"] = {
+						startTimestamp = 0,
+						type = "permabuy",
+						endTimestamp = nil,
+					},
+					["grace-period-record"] = {
+						startTimestamp = 0,
+						type = "lease",
+						endTimestamp = endTimestamp - constants.gracePeriodMs,
+					},
+				},
+			}
+			local arnsStats = arns.getArNSStatsBetweenTimestamps(currentTimestamp, endTimestamp)
+			assert.are.equal(2, arnsStats.totalActiveNames)
+			assert.are.equal(1, arnsStats.totalGracePeriodNames)
+			assert.are.equal(2, arnsStats.totalReservedNames)
+			assert.are.equal(1, arnsStats.totalReturnedNames)
+		end)
+	end)
+
 	describe("pruneReservedNames", function()
 		it("should remove expired reserved names", function()
 			local currentTimestamp = 1000000

--- a/spec/arns_spec.lua
+++ b/spec/arns_spec.lua
@@ -1231,10 +1231,9 @@ describe("arns", function()
 		end)
 	end)
 
-	describe("getArNSStatsBetweenTimestamps", function()
+	describe("getArNSStatsAtTimestamp", function()
 		it("should return the correct ArNS stats", function()
 			local currentTimestamp = constants.gracePeriodMs
-			local endTimestamp = currentTimestamp + 1000000
 			_G.NameRegistry = {
 				returned = {
 					["returned-record"] = {
@@ -1263,7 +1262,7 @@ describe("arns", function()
 					["active-record"] = {
 						startTimestamp = 0,
 						type = "lease",
-						endTimestamp = endTimestamp * 2,
+						endTimestamp = currentTimestamp * 2,
 					},
 					-- this should not be counted as an active name since it's expired
 					["expired-record"] = {
@@ -1275,21 +1274,22 @@ describe("arns", function()
 					["future-record"] = {
 						startTimestamp = currentTimestamp + 1,
 						type = "lease",
-						endTimestamp = endTimestamp * 2,
+						endTimestamp = currentTimestamp * 2,
 					},
 					["permabuy-record"] = {
 						startTimestamp = 0,
 						type = "permabuy",
 						endTimestamp = nil,
 					},
+					-- record is in the grace period at the current timestamp
 					["grace-period-record"] = {
 						startTimestamp = 0,
 						type = "lease",
-						endTimestamp = endTimestamp - constants.gracePeriodMs,
+						endTimestamp = currentTimestamp - constants.gracePeriodMs + 1,
 					},
 				},
 			}
-			local arnsStats = arns.getArNSStatsBetweenTimestamps(currentTimestamp, endTimestamp)
+			local arnsStats = arns.getArNSStatsAtTimestamp(currentTimestamp)
 			assert.are.equal(2, arnsStats.totalActiveNames)
 			assert.are.equal(1, arnsStats.totalGracePeriodNames)
 			assert.are.equal(2, arnsStats.totalReservedNames)

--- a/spec/epochs_spec.lua
+++ b/spec/epochs_spec.lua
@@ -608,6 +608,7 @@ describe("epochs", function()
 					purchasePrice = 0,
 					undernameLimit = 10,
 				},
+				-- active at the beginning of the epoch, but will go into grace period during the epoch, so next epoch will be count it in grace period
 				["this-is-a-record-in-grace-period"] = {
 					startTimestamp = recordTimestamp,
 					endTimestamp = epochEndTimestamp - 1,
@@ -640,8 +641,8 @@ describe("epochs", function()
 
 			-- Check arnsStats are counted as expected
 			assert.are.same({
-				totalActiveNames = 2,
-				totalGracePeriodNames = 1,
+				totalActiveNames = 3,
+				totalGracePeriodNames = 0,
 				totalReservedNames = 2,
 				totalReturnedNames = 1,
 			}, result.arnsStats)

--- a/spec/primary_names_spec.lua
+++ b/spec/primary_names_spec.lua
@@ -24,6 +24,7 @@ describe("Primary Names", function()
 		it("should fail if the caller does not have a balance", function()
 			_G.NameRegistry.records = {
 				["test"] = {
+					startTimestamp = 0,
 					processId = "base-name-owner",
 					type = "lease",
 					endTimestamp = 1234567890 + 30 * 24 * 60 * 60 * 1000,
@@ -120,6 +121,7 @@ describe("Primary Names", function()
 				}
 				_G.NameRegistry.records = {
 					["test"] = {
+						startTimestamp = 0,
 						processId = "processId",
 						type = "lease",
 						endTimestamp = 1234567890 + 30 * 24 * 60 * 60 * 1000,

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -387,12 +387,12 @@ local function getTotalArNSNamesBetweenTimestampsUnsafe(startTimestamp, endTimes
 		if record.type == "permabuy" then
 			totalActiveNames = totalActiveNames + 1
 		elseif record.type == "lease" and record.endTimestamp then
-			-- record is active between the start and end timestamps
+			-- record is active for the entire period between the two timestamps
 			if record.startTimestamp <= startTimestamp and record.endTimestamp >= endTimestamp then
 				totalActiveNames = totalActiveNames + 1
 			elseif
-				-- record is in the grace period between the start and end timestamps
-				record.startTimestamp <= startTimestamp
+				-- record is in the grace period for the entire period between the two timestamps
+				record.endTimestamp >= startTimestamp
 				and record.endTimestamp + constants.gracePeriodMs >= endTimestamp
 			then
 				totalGracePeriodNames = totalGracePeriodNames + 1

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -387,9 +387,11 @@ local function getTotalArNSNamesBetweenTimestampsUnsafe(startTimestamp, endTimes
 		if record.type == "permabuy" then
 			totalActiveNames = totalActiveNames + 1
 		elseif record.type == "lease" and record.endTimestamp then
+			-- record is active between the start and end timestamps
 			if record.startTimestamp <= startTimestamp and record.endTimestamp >= endTimestamp then
 				totalActiveNames = totalActiveNames + 1
 			elseif
+				-- record is in the grace period between the start and end timestamps
 				record.startTimestamp <= startTimestamp
 				and record.endTimestamp + constants.gracePeriodMs >= endTimestamp
 			then
@@ -408,7 +410,8 @@ local function getTotalReservedNamesBetweenTimestampsUnsafe(_, endTimestamp)
 	local reservedNames = arns.getReservedNamesUnsafe()
 	local totalReservedNames = 0
 	for _, reservedName in pairs(reservedNames) do
-		if not reservedName.endTimestamp or endTimestamp <= reservedName.endTimestamp then
+		-- reserved name is active between the start and end timestamps
+		if not reservedName.endTimestamp or reservedName.endTimestamp >= endTimestamp then
 			totalReservedNames = totalReservedNames + 1
 		end
 	end
@@ -420,8 +423,11 @@ local function getTotalReturnedNamesBetweenTimestampsUnsafe(startTimestamp, endT
 	local totalReturnedNames = 0
 
 	for _, returnedName in pairs(returnedNames) do
-		local returnedNameEndTimestamp = returnedName.startTimestamp + constants.returnedNamePeriod
-		if returnedName.startTimestamp <= startTimestamp and returnedNameEndTimestamp >= endTimestamp then
+		-- returned name is active between the start and end timestamps
+		if
+			returnedName.startTimestamp <= startTimestamp
+			and returnedName.startTimestamp + constants.returnedNamePeriod >= endTimestamp
+		then
 			totalReturnedNames = totalReturnedNames + 1
 		end
 	end

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -389,7 +389,10 @@ local function getTotalArNSNamesBetweenTimestampsUnsafe(startTimestamp, endTimes
 		elseif record.type == "lease" and record.endTimestamp then
 			if record.startTimestamp <= startTimestamp and record.endTimestamp >= endTimestamp then
 				totalActiveNames = totalActiveNames + 1
-			elseif record.endTimestamp + constants.gracePeriodMs >= endTimestamp then
+			elseif
+				record.startTimestamp <= startTimestamp
+				and record.endTimestamp + constants.gracePeriodMs >= endTimestamp
+			then
 				totalGracePeriodNames = totalGracePeriodNames + 1
 			end
 		end
@@ -415,10 +418,10 @@ end
 local function getTotalReturnedNamesBetweenTimestampsUnsafe(startTimestamp, endTimestamp)
 	local returnedNames = arns.getReturnedNamesUnsafe()
 	local totalReturnedNames = 0
-	local returnedNameEndTimestamp = startTimestamp + constants.returnedNamePeriod
 
 	for _, returnedName in pairs(returnedNames) do
-		if startTimestamp >= returnedName.startTimestamp and endTimestamp <= returnedNameEndTimestamp then
+		local returnedNameEndTimestamp = returnedName.startTimestamp + constants.returnedNamePeriod
+		if returnedName.startTimestamp <= startTimestamp and returnedNameEndTimestamp >= endTimestamp then
 			totalReturnedNames = totalReturnedNames + 1
 		end
 	end

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -405,7 +405,7 @@ local function getTotalReservedNamesBetweenTimestampsUnsafe(_, endTimestamp)
 	local reservedNames = arns.getReservedNamesUnsafe()
 	local totalReservedNames = 0
 	for _, reservedName in pairs(reservedNames) do
-		if endTimestamp <= reservedName.endTimestamp then
+		if not reservedName.endTimestamp or endTimestamp <= reservedName.endTimestamp then
 			totalReservedNames = totalReservedNames + 1
 		end
 	end

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -362,16 +362,7 @@ function arns.getActiveArNSNamesBetweenTimestamps(startTimestamp, endTimestamp)
 	local records = arns.getRecordsUnsafe()
 	local activeNames = {}
 	for name, record in pairs(records) do
-		if
-			record.type == "permabuy"
-			or (
-				record.type == "lease"
-				and record.endTimestamp
-				and record.startTimestamp
-				and record.startTimestamp <= startTimestamp
-				and record.endTimestamp >= endTimestamp
-			)
-		then
+		if arns.recordIsActive(record, startTimestamp) and arns.recordIsActive(record, endTimestamp) then
 			table.insert(activeNames, name)
 		end
 	end

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -19,7 +19,7 @@ local epochs = {}
 --- @field observations Observations The observations of the epoch
 --- @field arnsStats ArNSStats The ArNS stats for the epoch
 
---- @class ArNSStats # The ArNS stats
+--- @class ArNSStats # The ArNS stats for an epoch
 --- @field totalActiveNames number The total active ArNS names
 --- @field totalGracePeriodNames number The total grace period ArNS names
 --- @field totalReservedNames number The total reserved ArNS names

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -402,7 +402,8 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 	local activeGateways = gar.getActiveGatewaysBeforeTimestamp(epochStartTimestamp)
 	-- get the max rewards for each participant eligible for the epoch
 	local eligibleEpochRewards = epochs.computeTotalEligibleRewardsForEpoch(epochIndex, prescribedObservers)
-	local arnsStatsForEpoch = arns.getArNSStatsBetweenTimestamps(epochStartTimestamp, epochEndTimestamp)
+	-- snapshot the ARNS stats at the beginning of the epoch, does not account for any names that are created or expire during the epoch
+	local arnsStatsAtEpochStart = arns.getArNSStatsAtTimestamp(epochStartTimestamp)
 	--- @type PrescribedEpoch
 	local epoch = {
 		epochIndex = epochIndex,
@@ -425,7 +426,7 @@ function epochs.createEpoch(timestamp, blockHeight, hashchain)
 				eligible = eligibleEpochRewards.potentialRewards,
 			},
 		},
-		arnsStats = arnsStatsForEpoch,
+		arnsStats = arnsStatsAtEpochStart,
 	}
 	Epochs[epochIndex] = epoch
 	-- update the gateway weights


### PR DESCRIPTION
These stats are computed at the beginning of an epoch, and just used for historical tracking. Every epoch has a start and timestamp - and these stats are computed at the beginning on an epoch.

- Active names: at the beginning of an epoch, these names are ACTIVE
- Reserved names: at the beginnog of an epoch, these names are RESERVED
- Returned names: at the beginning of an epoch these names are RETURNED
- Grace period names: at the beginning of an epoch, these names are in their GRACE PERIOD