### PR TITLE
fix(gar): update slash rate to 1, standardize time conversions

### DIFF
--- a/spec/arns_spec.lua
+++ b/spec/arns_spec.lua
@@ -144,7 +144,7 @@ describe("arns", function()
 						undernameLimit = 10,
 						processId = testProcessId,
 						startTimestamp = 0,
-						endTimestamp = timestamp + constants.oneYearMs * 1,
+						endTimestamp = timestamp + constants.yearsToMs(1),
 					}, result.record)
 					assert.are.same({
 						["test-name"] = {
@@ -153,7 +153,7 @@ describe("arns", function()
 							undernameLimit = 10,
 							processId = testProcessId,
 							startTimestamp = 0,
-							endTimestamp = timestamp + constants.oneYearMs * 1,
+							endTimestamp = timestamp + constants.yearsToMs(1),
 						},
 					}, _G.NameRegistry.records)
 					assert.are.equal(startBalance - 600000000, _G.Balances[testAddress])
@@ -186,7 +186,7 @@ describe("arns", function()
 						undernameLimit = 10,
 						processId = testProcessId,
 						startTimestamp = 0,
-						endTimestamp = timestamp + constants.oneYearMs * 1,
+						endTimestamp = timestamp + constants.yearsToMs(1),
 					}, buyRecordResult.record)
 					assert.are.same({
 						["test-name"] = {
@@ -195,7 +195,7 @@ describe("arns", function()
 							undernameLimit = 10,
 							processId = testProcessId,
 							startTimestamp = 0,
-							endTimestamp = timestamp + constants.oneYearMs * 1,
+							endTimestamp = timestamp + constants.yearsToMs(1),
 						},
 					}, _G.NameRegistry.records)
 					assert.are.equal(startBalance - discountTotal, _G.Balances[testAddress])
@@ -217,7 +217,7 @@ describe("arns", function()
 						undernameLimit = 10,
 						processId = testProcessId,
 						startTimestamp = 0,
-						endTimestamp = timestamp + constants.oneYearMs,
+						endTimestamp = timestamp + constants.yearsToMs(1),
 					}, result.record)
 					assert.are.same({
 						purchasePrice = 600000000,
@@ -225,7 +225,7 @@ describe("arns", function()
 						undernameLimit = 10,
 						processId = testProcessId,
 						startTimestamp = 0,
-						endTimestamp = timestamp + constants.oneYearMs,
+						endTimestamp = timestamp + constants.yearsToMs(1),
 					}, arns.getRecord("test-name"))
 
 					assert.is.equal(
@@ -259,7 +259,7 @@ describe("arns", function()
 
 			it("should throw an error if the record already exists [" .. addressType .. "]", function()
 				local existingRecord = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -297,7 +297,7 @@ describe("arns", function()
 				}
 				local result = arns.buyRecord("test-name", "lease", 1, testAddress, timestamp, testProcessId)
 				local expectation = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -335,7 +335,7 @@ describe("arns", function()
 						arns.buyRecord("test-name", "lease", 1, testAddress, timestamp, testProcessId, "msd-id")
 					local expectedPrice = math.floor(600000000 * constants.returnedNameMaxMultiplier)
 					local expectation = {
-						endTimestamp = timestamp + constants.oneYearMs,
+						endTimestamp = timestamp + constants.yearsToMs(1),
 						processId = testProcessId,
 						purchasePrice = expectedPrice,
 						startTimestamp = 0,
@@ -372,7 +372,7 @@ describe("arns", function()
 			--  throw an error on insufficient balance
 			it("should throw an error on insufficient balance [" .. addressType .. "]", function()
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -387,7 +387,7 @@ describe("arns", function()
 
 			it("should throw an error if the name is in the grace period [" .. addressType .. "]", function()
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -399,7 +399,7 @@ describe("arns", function()
 					testAddress,
 					"test-name",
 					1,
-					timestamp + constants.oneYearMs + 1,
+					timestamp + constants.yearsToMs(1) + 1,
 					"msg-id",
 					"balance"
 				)
@@ -409,7 +409,7 @@ describe("arns", function()
 
 			it("should increase the undername count and properly deduct balance [" .. addressType .. "]", function()
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -420,7 +420,7 @@ describe("arns", function()
 				local purchasesBefore = demand.getCurrentPeriodPurchases()
 				local result = arns.increaseundernameLimit(testAddress, "test-name", 50, timestamp, "msg-id")
 				local expectation = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -455,7 +455,7 @@ describe("arns", function()
 				assert.is_true(gar.isEligibleForArNSDiscount(testAddress))
 
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -466,7 +466,7 @@ describe("arns", function()
 				local purchasesBefore = demand.getCurrentPeriodPurchases()
 				local result = arns.increaseundernameLimit(testAddress, "test-name", 50, timestamp)
 				local expectation = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -506,7 +506,7 @@ describe("arns", function()
 				"should throw an error if the lease is expired and beyond the grace period [" .. addressType .. "]",
 				function()
 					_G.NameRegistry.records["test-name"] = {
-						endTimestamp = timestamp + constants.oneYearMs,
+						endTimestamp = timestamp + constants.yearsToMs(1),
 						processId = testProcessId,
 						purchasePrice = 600000000,
 						startTimestamp = 0,
@@ -518,7 +518,7 @@ describe("arns", function()
 						testAddress,
 						"test-name",
 						1,
-						timestamp + constants.oneYearMs + constants.gracePeriodMs + 1
+						timestamp + constants.yearsToMs(1) + constants.gracePeriodMs + 1
 					)
 					assert.is_false(status)
 					assert.match("Name is expired", error)
@@ -542,7 +542,7 @@ describe("arns", function()
 			-- throw an error of insufficient balance
 			it("should throw an error on insufficient balance [" .. addressType .. "]", function()
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -558,7 +558,7 @@ describe("arns", function()
 			it("should allow extension for existing lease up to 5 years [" .. addressType .. "]", function()
 				_G.NameRegistry.records["test-name"] = {
 					-- 1 year lease
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -569,7 +569,7 @@ describe("arns", function()
 				local purchasesBefore = demand.getCurrentPeriodPurchases()
 				local result = arns.extendLease(testAddress, "test-name", 4, timestamp)
 				assert.are.same({
-					endTimestamp = timestamp + constants.oneYearMs * 5,
+					endTimestamp = timestamp + constants.yearsToMs(5),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -578,7 +578,7 @@ describe("arns", function()
 				}, result.record)
 				assert.are.same({
 					["test-name"] = {
-						endTimestamp = timestamp + constants.oneYearMs * 5,
+						endTimestamp = timestamp + constants.yearsToMs(5),
 						processId = testProcessId,
 						purchasePrice = 600000000,
 						startTimestamp = 0,
@@ -616,7 +616,7 @@ describe("arns", function()
 			it("should throw an error when trying to extend beyond 5 years [" .. addressType .. "]", function()
 				_G.NameRegistry.records["test-name"] = {
 					-- 1 year lease
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -639,7 +639,7 @@ describe("arns", function()
 
 				_G.NameRegistry.records["test-name"] = {
 					-- 1 year lease
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -650,7 +650,7 @@ describe("arns", function()
 				local purchasesBefore = demand.getCurrentPeriodPurchases()
 				local extendLeaseResult = arns.extendLease(testAddress, "test-name", 4, timestamp)
 				assert.are.same({
-					endTimestamp = timestamp + constants.oneYearMs * 5,
+					endTimestamp = timestamp + constants.yearsToMs(5),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -659,7 +659,7 @@ describe("arns", function()
 				}, extendLeaseResult.record)
 				assert.are.same({
 					["test-name"] = {
-						endTimestamp = timestamp + constants.oneYearMs * 5,
+						endTimestamp = timestamp + constants.yearsToMs(5),
 						processId = testProcessId,
 						purchasePrice = 600000000,
 						startTimestamp = 0,
@@ -706,7 +706,7 @@ describe("arns", function()
 			it("should successfully reassign a name to a new owner", function()
 				-- Setup initial record
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -731,7 +731,7 @@ describe("arns", function()
 			it("should throw an error if the reassigner is not the current owner", function()
 				-- Setup initial record
 				_G.NameRegistry.records["test-name"] = {
-					endTimestamp = timestamp + constants.oneYearMs,
+					endTimestamp = timestamp + constants.yearsToMs(1),
 					processId = testProcessId,
 					purchasePrice = 600000000,
 					startTimestamp = 0,
@@ -830,7 +830,7 @@ describe("arns", function()
 		end)
 		it("should return the correct token cost for increasing undername limit", function()
 			_G.NameRegistry.records["test-name"] = {
-				endTimestamp = constants.oneYearMs,
+				endTimestamp = constants.yearsToMs(1),
 				processId = testProcessId,
 				purchasePrice = 600000000,
 				startTimestamp = 0,
@@ -846,14 +846,14 @@ describe("arns", function()
 				intent = "Increase-Undername-Limit",
 				quantity = 5,
 				name = "test-name",
-				currentTimestamp = constants.oneYearMs / 2,
+				currentTimestamp = constants.yearsToMs(1) / 2,
 			}
 			_G.DemandFactor.currentDemandFactor = demandFactor
 			assert.are.equal(expectedCost, arns.getTokenCost(intendedAction).tokenCost)
 		end)
 		it("should return the token cost for extending a lease", function()
 			_G.NameRegistry.records["test-name"] = {
-				endTimestamp = timestamp + constants.oneYearMs,
+				endTimestamp = timestamp + constants.yearsToMs(1),
 				processId = testProcessId,
 				purchasePrice = 600000000,
 				startTimestamp = 0,
@@ -868,7 +868,7 @@ describe("arns", function()
 				intent = "Extend-Lease",
 				years = 2,
 				name = "test-name",
-				currentTimestamp = timestamp + constants.oneYearMs,
+				currentTimestamp = timestamp + constants.yearsToMs(1),
 			}
 			_G.DemandFactor.currentDemandFactor = demandFactor
 			assert.are.equal(expectedCost, arns.getTokenCost(intendedAction).tokenCost)
@@ -1000,7 +1000,7 @@ describe("arns", function()
 				intent = "Extend-Lease",
 				years = 2,
 				name = "test-name",
-				currentTimestamp = timestamp + constants.oneYearMs,
+				currentTimestamp = timestamp + constants.yearsToMs(1),
 			})
 			assert.is_false(status)
 			assert.match("Name is permanently owned and cannot be extended", error)
@@ -1188,7 +1188,7 @@ describe("arns", function()
 				}, newGracePeriodRecords)
 				-- ensure the next prune timestamp is updated to the grace period record end timestamp
 				assert.are.equal(
-					_G.NameRegistry.records["active-record"].endTimestamp + constants.twoWeeksMs,
+					_G.NameRegistry.records["active-record"].endTimestamp + constants.daysToMs(14),
 					_G.NextRecordsPruneTimestamp
 				)
 			end

--- a/spec/gar_spec.lua
+++ b/spec/gar_spec.lua
@@ -1984,7 +1984,7 @@ describe("gar", function()
 						startTimestamp = currentTimestamp - 100,
 						endTimestamp = 0, -- Not expired, but failedConsecutiveEpochs is 30
 						status = "joined",
-						operatorStake = minOperatorStake + 10000, -- will slash 20% of the min operator stake
+						operatorStake = minOperatorStake + 10000, -- will slash 100% of the min operator stake
 						vaults = {},
 						delegates = {},
 						stats = {
@@ -1998,7 +1998,8 @@ describe("gar", function()
 				-- Call pruneGateways
 				local protocolBalanceBefore = _G.Balances[ao.id] or 0
 				local result = gar.pruneGateways(currentTimestamp, msgId)
-				local expectedSlashedStake = math.floor(minOperatorStake * 0.2)
+				local expectedSlashedStake = minOperatorStake -- the full operator stake should be slashed
+				local expectedRemainingStake = 10000 -- the remaining stake should be the operator stake minus the slashed stake plus the remaining stake
 				assert.are.same({
 					prunedGateways = { "address1" },
 					slashedGateways = {
@@ -2008,7 +2009,7 @@ describe("gar", function()
 					delegateStakeReturned = 0,
 					gatewayStakeReturned = 0,
 					delegateStakeWithdrawing = 0,
-					gatewayStakeWithdrawing = 8000010000,
+					gatewayStakeWithdrawing = expectedRemainingStake,
 					gatewayObjectTallies = {
 						numDelegateVaults = 0,
 						numDelegatesVaulting = 0,
@@ -2022,11 +2023,10 @@ describe("gar", function()
 					},
 				}, result)
 
-				local expectedRemainingStake = math.floor(minOperatorStake * 0.8) + 10000
 				assert.is_nil(_G.GatewayRegistry["address1"]) -- removed
 				assert.is_not_nil(_G.GatewayRegistry["address2"]) -- not removed
 				assert.is_not_nil(_G.GatewayRegistry["address3"]) -- not removed
-				-- Check that gateway 3's operator stake is slashed by 20% and the remaining stake is vaulted
+				-- Check that gateway 3's operator stake is slashed by 100% and the remaining stake is vaulted
 				assert.are.equal("leaving", _G.GatewayRegistry["address3"].status)
 				assert.are.equal(0, _G.GatewayRegistry["address3"].operatorStake)
 				assert.are.same({

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -130,7 +130,7 @@ function arns.buyRecord(name, purchaseType, years, from, timestamp, processId, m
 		type = purchaseType,
 		undernameLimit = constants.DEFAULT_UNDERNAME_COUNT,
 		purchasePrice = totalFee,
-		endTimestamp = purchaseType == "lease" and timestamp + constants.oneYearMs * years or nil,
+		endTimestamp = purchaseType == "lease" and timestamp + constants.yearsToMs(years) or nil,
 	}
 
 	-- Register the leased or permanently owned name
@@ -254,7 +254,7 @@ function arns.extendLease(from, name, years, currentTimestamp, msgId, fundFrom)
 	assert(fundingResult.totalFunded == totalFee, "Funding plan application failed")
 
 	-- modify the record with the new end timestamp
-	arns.modifyRecordEndTimestamp(name, record.endTimestamp + constants.oneYearMs * years)
+	arns.modifyRecordEndTimestamp(name, record.endTimestamp + constants.yearsToMs(years))
 
 	-- Transfer tokens to the protocol balance
 	balances.increaseBalance(ao.id, totalFee)
@@ -502,7 +502,7 @@ end
 function arns.modifyRecordEndTimestamp(name, newEndTimestamp)
 	local record = arns.getRecord(name)
 	assert(record, "Name is not registered")
-	local maxLeaseLength = constants.maxLeaseLengthYears * constants.oneYearMs
+	local maxLeaseLength = constants.maxLeaseLengthYears * constants.yearsToMs(1)
 	local maxEndTimestamp = record.startTimestamp + maxLeaseLength
 	assert(newEndTimestamp <= maxEndTimestamp, "Cannot extend lease beyond 5 years")
 	NameRegistry.records[name].endTimestamp = newEndTimestamp
@@ -574,7 +574,7 @@ end
 --- @param endTimestamp number The end timestamp
 --- @return number yearsBetweenTimestamps - the number of years between the two timestamps
 function arns.calculateYearsBetweenTimestamps(startTimestamp, endTimestamp)
-	local yearsRemainingFloat = (endTimestamp - startTimestamp) / constants.oneYearMs
+	local yearsRemainingFloat = (endTimestamp - startTimestamp) / constants.yearsToMs(1)
 	return yearsRemainingFloat
 end
 
@@ -646,7 +646,7 @@ function arns.getMaxAllowedYearsExtensionForRecord(record, currentTimestamp)
 	end
 
 	-- TODO: should we put this as the ceiling? or should we allow people to extend as soon as it is purchased
-	local yearsRemainingOnLease = math.ceil((record.endTimestamp - currentTimestamp) / constants.oneYearMs)
+	local yearsRemainingOnLease = math.ceil((record.endTimestamp - currentTimestamp) / constants.yearsToMs(1))
 
 	-- a number between 0 and 5 (MAX_YEARS)
 	return constants.maxLeaseLengthYears - yearsRemainingOnLease

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -1,9 +1,13 @@
 local constants = {}
 
+-- @alias mARIO number
+-- intentionally not exposed so all callers use ARIOToMARIO for consistency
+local mARIO_PER_ARIO = 1000000
+
 --- @param ARIO number
 --- @return mARIO mARIO the amount of mario for the given ARIO
 function constants.ARIOToMARIO(ARIO)
-	return ARIO * 1000000
+	return ARIO * mARIO_PER_ARIO
 end
 
 --- @param days number

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -3,6 +3,7 @@ local constants = {}
 constants.oneYearSeconds = 60 * 60 * 24 * 365
 constants.thirtyDaysSeconds = 60 * 60 * 24 * 30
 
+constants.oneMinuteMs = 1000 * 60
 constants.oneHourMs = 1000 * 60 * 60
 constants.oneDayMs = constants.oneHourMs * 24
 constants.oneWeekMs = constants.oneDayMs * 7
@@ -17,8 +18,27 @@ function constants.ARIOToMARIO(ARIO)
 	return ARIO * constants.mARIOPerARIO
 end
 
+--- @param days number
+--- @return number milliseconds the number of days in milliseconds
+function constants.daysToMs(days)
+	return days * constants.oneDayMs
+end
+
+--- @param minutes number
+--- @return number milliseconds the number of minutes in milliseconds
+function constants.minutesToMs(minutes)
+	return minutes * constants.oneMinuteMs
+end
+
+--- @param years number
+--- @return number milliseconds the number of years in milliseconds
+function constants.yearsToMs(years)
+	return years * constants.oneYearMs
+end
+
 -- EPOCHS
 constants.defaultEpochDurationMs = constants.oneDayMs
+constants.distributionDelayMs = constants.minutesToMs(40) -- 40 minutes
 constants.maximumRewardRate = 0.001
 constants.minimumRewardRate = 0.0005
 constants.rewardDecayStartEpoch = 365
@@ -28,7 +48,6 @@ constants.gatewayOperatorRewardRatio = 0.9
 
 -- GAR
 constants.DEFAULT_UNDERNAME_COUNT = 10
-constants.DEADLINE_DURATION_MS = constants.oneHourMs
 constants.totalTokenSupply = constants.ARIOToMARIO(1000000000) -- 1 billion tokens
 constants.MIN_EXPEDITED_WITHDRAWAL_PENALTY_RATE = 0.10 -- the minimum penalty rate for an expedited withdrawal (10% of the amount being withdrawn)
 constants.MAX_EXPEDITED_WITHDRAWAL_PENALTY_RATE = 0.50 -- the maximum penalty rate for an expedited withdrawal (50% of the amount being withdrawn)
@@ -46,14 +65,13 @@ constants.MIN_NAME_LENGTH = 1
 -- - Does not allow names to start or end with a hyphen
 constants.ARNS_NAME_REGEX = "^%w[%w-]*%w?$"
 constants.DEFAULT_UNDERNAME_COUNT = 10
-constants.DEADLINE_DURATION_MS = constants.oneHourMs
 constants.PERMABUY_LEASE_FEE_LENGTH = 20 -- 20 years
 constants.ANNUAL_PERCENTAGE_FEE = 0.2 -- 20%
 constants.ARNS_NAME_DOES_NOT_EXIST_MESSAGE = "Name not found in the ArNS Registry!"
 constants.UNDERNAME_LEASE_FEE_PERCENTAGE = 0.001
 constants.UNDERNAME_PERMABUY_FEE_PERCENTAGE = 0.005
 constants.PRIMARY_NAME_REQUEST_COST = constants.ARIOToMARIO(10) -- 10 ARIO
-constants.gracePeriodMs = constants.twoWeeksMs
+constants.gracePeriodMs = constants.daysToMs(14)
 constants.maxLeaseLengthYears = 5
 constants.returnedNamePeriod = constants.twoWeeksMs
 constants.returnedNameMaxMultiplier = 50 -- Freshly returned names will have a multiplier of 50x
@@ -66,7 +84,7 @@ constants.ARNS_DISCOUNT_NAME = "ArNS Discount"
 -- DEMAND
 constants.demandSettings = {
 	movingAvgPeriodCount = 7,
-	periodLengthMs = 60 * 1000 * 24, -- one day
+	periodLengthMs = constants.oneDayMs, -- one day
 	demandFactorBaseValue = 1,
 	demandFactorMin = 0.5,
 	demandFactorUpAdjustment = 0.05,
@@ -77,8 +95,8 @@ constants.demandSettings = {
 
 -- VAULTS
 constants.MIN_VAULT_SIZE = constants.ARIOToMARIO(100) -- 100 ARIO
-constants.MAX_TOKEN_LOCK_TIME_MS = 12 * 365 * 24 * 60 * 60 * 1000 -- The maximum amount of blocks tokens can be locked in a vault (12 years of blocks)
-constants.MIN_TOKEN_LOCK_TIME_MS = 14 * 24 * 60 * 60 * 1000 -- The minimum amount of blocks tokens can be locked in a vault (14 days of blocks)
+constants.MAX_TOKEN_LOCK_TIME_MS = constants.yearsToMs(12) -- The maximum amount of blocks tokens can be locked in a vault (12 years of blocks)
+constants.MIN_TOKEN_LOCK_TIME_MS = constants.daysToMs(14) -- The minimum amount of blocks tokens can be locked in a vault (14 days of blocks)
 
 -- ARNS FEES
 constants.genesisFees = {

--- a/src/constants.lua
+++ b/src/constants.lua
@@ -1,43 +1,39 @@
 local constants = {}
 
-constants.oneYearSeconds = 60 * 60 * 24 * 365
-constants.thirtyDaysSeconds = 60 * 60 * 24 * 30
-
-constants.oneMinuteMs = 1000 * 60
-constants.oneHourMs = 1000 * 60 * 60
-constants.oneDayMs = constants.oneHourMs * 24
-constants.oneWeekMs = constants.oneDayMs * 7
-constants.twoWeeksMs = constants.oneWeekMs * 2
-constants.oneYearMs = 31536000 * 1000
-
-constants.mARIOPerARIO = 1000000
-
 --- @param ARIO number
---- @return mARIO
+--- @return mARIO mARIO the amount of mario for the given ARIO
 function constants.ARIOToMARIO(ARIO)
-	return ARIO * constants.mARIOPerARIO
+	return ARIO * 1000000
 end
 
 --- @param days number
 --- @return number milliseconds the number of days in milliseconds
 function constants.daysToMs(days)
-	return days * constants.oneDayMs
+	return days * constants.hoursToMs(24)
 end
 
 --- @param minutes number
 --- @return number milliseconds the number of minutes in milliseconds
 function constants.minutesToMs(minutes)
-	return minutes * constants.oneMinuteMs
+	return minutes * constants.secondsToMs(60)
+end
+
+function constants.secondsToMs(seconds)
+	return seconds * 1000
 end
 
 --- @param years number
 --- @return number milliseconds the number of years in milliseconds
 function constants.yearsToMs(years)
-	return years * constants.oneYearMs
+	return years * constants.daysToMs(365)
+end
+
+function constants.hoursToMs(hours)
+	return hours * constants.minutesToMs(60)
 end
 
 -- EPOCHS
-constants.defaultEpochDurationMs = constants.oneDayMs
+constants.defaultEpochDurationMs = constants.daysToMs(1)
 constants.distributionDelayMs = constants.minutesToMs(40) -- 40 minutes
 constants.maximumRewardRate = 0.001
 constants.minimumRewardRate = 0.0005
@@ -51,8 +47,8 @@ constants.DEFAULT_UNDERNAME_COUNT = 10
 constants.totalTokenSupply = constants.ARIOToMARIO(1000000000) -- 1 billion tokens
 constants.MIN_EXPEDITED_WITHDRAWAL_PENALTY_RATE = 0.10 -- the minimum penalty rate for an expedited withdrawal (10% of the amount being withdrawn)
 constants.MAX_EXPEDITED_WITHDRAWAL_PENALTY_RATE = 0.50 -- the maximum penalty rate for an expedited withdrawal (50% of the amount being withdrawn)
-constants.minimumWithdrawalAmount = constants.mARIOPerARIO -- the minimum amount that can be withdrawn from the GAR
-constants.redelegationFeeResetIntervalMs = constants.defaultEpochDurationMs * 7 -- 7 epochs
+constants.minimumWithdrawalAmount = constants.ARIOToMARIO(1) -- the minimum amount that can be withdrawn from the GAR
+constants.redelegationFeeResetIntervalMs = constants.daysToMs(7) -- 7 days
 constants.maxDelegateRewardShareRatio = 95 -- 95% of rewards can be shared with delegates
 
 -- ARNS
@@ -73,7 +69,7 @@ constants.UNDERNAME_PERMABUY_FEE_PERCENTAGE = 0.005
 constants.PRIMARY_NAME_REQUEST_COST = constants.ARIOToMARIO(10) -- 10 ARIO
 constants.gracePeriodMs = constants.daysToMs(14)
 constants.maxLeaseLengthYears = 5
-constants.returnedNamePeriod = constants.twoWeeksMs
+constants.returnedNamePeriod = constants.daysToMs(14)
 constants.returnedNameMaxMultiplier = 50 -- Freshly returned names will have a multiplier of 50x
 
 constants.ARNS_DISCOUNT_PERCENTAGE = 0.2
@@ -84,7 +80,7 @@ constants.ARNS_DISCOUNT_NAME = "ArNS Discount"
 -- DEMAND
 constants.demandSettings = {
 	movingAvgPeriodCount = 7,
-	periodLengthMs = constants.oneDayMs, -- one day
+	periodLengthMs = constants.daysToMs(1), -- one day
 	demandFactorBaseValue = 1,
 	demandFactorMin = 0.5,
 	demandFactorUpAdjustment = 0.05,

--- a/src/demand.lua
+++ b/src/demand.lua
@@ -37,7 +37,7 @@ DemandFactorSettings = DemandFactorSettings
 	or {
 		periodZeroStartTimestamp = 1722837600000, -- 08/05/2024 @ 12:00am (UTC)
 		movingAvgPeriodCount = 7,
-		periodLengthMs = 60 * 60 * 1000 * 24, -- one day in milliseconds
+		periodLengthMs = constants.daysToMs(1), -- one day in milliseconds
 		demandFactorBaseValue = 1,
 		demandFactorMin = 0.5,
 		demandFactorUpAdjustment = 0.05, -- 5%

--- a/src/epochs.lua
+++ b/src/epochs.lua
@@ -87,7 +87,7 @@ EpochSettings = EpochSettings
 		maxObservers = 50,
 		epochZeroStartTimestamp = 1719900000000, -- July 9th, 00:00:00 UTC
 		durationMs = constants.defaultEpochDurationMs, -- 24 hours
-		distributionDelayMs = 60 * 1000 * 40, -- 40 minutes (~ 20 arweave blocks)
+		distributionDelayMs = constants.distributionDelayMs, -- 40 minutes (~ 20 arweave blocks)
 	}
 
 --- @type Timestamp|nil

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -1054,7 +1054,7 @@ function gar.pruneGateways(currentTimestamp, msgId)
 				and garSettings ~= nil
 				and gateway.stats.failedConsecutiveEpochs >= garSettings.operators.failedEpochCountMax
 			then
-				-- slash the minimum operator stake and return it to the protocol balance, mark the gateway as leaving which will vault and remaining stake
+				-- slash the minimum operator stake and return it to the protocol balance; mark the gateway as leaving which will vault remaining stake
 				local slashableOperatorStake = math.min(gateway.operatorStake, garSettings.operators.minStake)
 				local slashAmount = math.floor(slashableOperatorStake * garSettings.operators.failedEpochSlashRate)
 				result.delegateStakeWithdrawing = result.delegateStakeWithdrawing + gateway.totalDelegatedStake

--- a/src/gar.lua
+++ b/src/gar.lua
@@ -100,19 +100,19 @@ GatewayRegistrySettings = {
 	observers = {
 		maxPerEpoch = 50,
 		tenureWeightDays = 180,
-		tenureWeightPeriod = 180 * 24 * 60 * 60 * 1000, -- approximately 180 days
+		tenureWeightPeriod = constants.daysToMs(180), -- 180 days in ms
 		maxTenureWeight = 4,
 	},
 	operators = {
 		minStake = constants.ARIOToMARIO(10000), -- 10,000 ARIO
-		withdrawLengthMs = 90 * 24 * 60 * 60 * 1000, -- 90 days to lower operator stake
-		leaveLengthMs = 90 * 24 * 60 * 60 * 1000, -- 90 days that balance will be vaulted
+		withdrawLengthMs = constants.daysToMs(90), -- 90 days to lower operator stake
+		leaveLengthMs = constants.daysToMs(90), -- 90 days that balance will be vaulted
 		failedEpochCountMax = 30, -- number of epochs failed before marked as leaving
-		failedEpochSlashRate = 0.2, -- 20% of stake is returned to protocol balance
+		failedEpochSlashRate = 1, -- 100% of the minimum operator stake is returned to protocol balance, rest is vaulted
 	},
 	delegates = {
 		minStake = constants.ARIOToMARIO(10), -- 10 ARIO
-		withdrawLengthMs = 90 * 24 * 60 * 60 * 1000, -- 90 days
+		withdrawLengthMs = constants.daysToMs(90), -- 90 days
 	},
 }
 
@@ -1054,7 +1054,7 @@ function gar.pruneGateways(currentTimestamp, msgId)
 				and garSettings ~= nil
 				and gateway.stats.failedConsecutiveEpochs >= garSettings.operators.failedEpochCountMax
 			then
-				-- slash 20% of the minimum operator stake and return the rest to the protocol balance, then mark the gateway as leaving
+				-- slash the minimum operator stake and return it to the protocol balance, mark the gateway as leaving which will vault and remaining stake
 				local slashableOperatorStake = math.min(gateway.operatorStake, garSettings.operators.minStake)
 				local slashAmount = math.floor(slashableOperatorStake * garSettings.operators.failedEpochSlashRate)
 				result.delegateStakeWithdrawing = result.delegateStakeWithdrawing + gateway.totalDelegatedStake

--- a/src/primary_names.lua
+++ b/src/primary_names.lua
@@ -99,7 +99,7 @@ function primaryNames.createPrimaryNameRequest(name, initiator, timestamp, msgId
 	local request = {
 		name = name,
 		startTimestamp = timestamp,
-		endTimestamp = timestamp + constants.oneWeekMs,
+		endTimestamp = timestamp + constants.daysToMs(7),
 	}
 
 	--- if the initiator is base name owner, then just set the primary name and return


### PR DESCRIPTION
100% fo the minimum operator stake will be slashed when a gateway is forced to leave.

Also - updates our constants and time conversions to all use utilities. Avoided putting in `utils` due to potential recursive dependency.