### PR TITLE
chore(testnet): add script to prune testnet

### DIFF
--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -3,7 +3,7 @@ name: AR.IO Testnet Reset
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 1 * *' # Run on the 1st of every month at 8AM ET
+    - cron: '0 12 1 * *' # Run on the 1st of every month at 12:00 UTC
 
 jobs:
   reset-testnet:

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -3,7 +3,7 @@ name: AR.IO Testnet Reset
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 */30 * *' # Run every 30 days
+    - cron: '0 8 1 * *' # Run on the 1st of every month at 8AM ET
 
 jobs:
   reset-testnet:
@@ -27,7 +27,7 @@ jobs:
           ARIO_PROTOCOL_BALANCE: ${{ vars.ARIO_PROTOCOL_BALANCE }}
           ARIO_TEAM_WALLET_BALANCE: ${{ vars.ARIO_TEAM_WALLET_BALANCE }}
           ARIO_TEAM_WALLET_ADDRESS: ${{ vars.ARIO_TEAM_WALLET_ADDRESS }}
-        run: yarn node tools/testnet-reset.mjs
+        run: yarn tools/testnet-reset.mjs
         id: reset
 
       - name: Notify Slack

--- a/.github/workflows/testnet.yaml
+++ b/.github/workflows/testnet.yaml
@@ -1,0 +1,39 @@
+name: AR.IO Testnet Reset
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 */30 * *' # Run every 30 days
+
+jobs:
+  reset-testnet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Reset Testnet
+        env:
+          WALLET: ${{ secrets.WALLET }}
+          ARIO_NETWORK_PROCESS_ID: ${{ vars.ARIO_NETWORK_PROCESS_ID }}
+          AO_CU_URL: ${{ vars.AO_CU_URL }}
+          ARIO_PROTOCOL_BALANCE: ${{ vars.ARIO_PROTOCOL_BALANCE }}
+          ARIO_TEAM_WALLET_BALANCE: ${{ vars.ARIO_TEAM_WALLET_BALANCE }}
+          ARIO_TEAM_WALLET_ADDRESS: ${{ vars.ARIO_TEAM_WALLET_ADDRESS }}
+        run: yarn node tools/testnet-reset.mjs
+        id: reset
+
+      - name: Notify Slack
+        uses: rtCamp/action-slack-notify@v2.3.2
+        env:
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_TITLE: $ARIO (testnet) Process Reset - ${{ job.status }}!
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          MSG_MINIMAL: true

--- a/tools/testnet-reset.mjs
+++ b/tools/testnet-reset.mjs
@@ -67,7 +67,3 @@ const { id } = await networkProcess.send({
   signer,
 });
 console.log(`Testnet reset tx: ${id}`);
-
-/**
- *
- */

--- a/tools/testnet-reset.mjs
+++ b/tools/testnet-reset.mjs
@@ -40,6 +40,7 @@ const { id } = await networkProcess.send({
     PrimaryNames.owners={}
     PrimaryNames.names={}
     GatewayRegistry={}
+    DemandFactor.currentDemandFactor=1
     NameRegistry.records={
       ardrive={
         processId = "FAoLsl-FuRYap2WCTLE1xkMzoK3fuu2Pq-E5-F9Cy-A",

--- a/tools/testnet-reset.mjs
+++ b/tools/testnet-reset.mjs
@@ -32,7 +32,8 @@ const teamWalletAddress = (
   .trim()
   .split(',');
 // the owner balance is the total supply minus the protocol balance and the team wallet balance
-const ownerBalance = totalSupply - protocolBalance - teamWalletBalance;
+const ownerBalance =
+  totalSupply - protocolBalance - teamWalletBalance * teamWalletAddress.length;
 const { id } = await networkProcess.send({
   tags: [{ name: 'Action', value: 'Eval' }],
   data: `
@@ -56,7 +57,6 @@ const { id } = await networkProcess.send({
       }
     }
     NameRegistry.returned={}
-    Epochs={}
     Balances={
       [Owner]=${ownerBalance},
       ${processId}=${protocolBalance},

--- a/tools/testnet-reset.mjs
+++ b/tools/testnet-reset.mjs
@@ -14,17 +14,20 @@ const signer = createAoSigner(new ArweaveSigner(wallet));
 const networkProcess = new AOProcess({
   processId,
   ao: connect({
-    CU_URL: process.env.AO_CU_URL,
+    CU_URL: process.env.AO_CU_URL || 'https://cu.ardrive.io',
   }),
 });
 
 const protocolBalance =
   process.env.ARIO_PROTOCOL_BALANCE ||
-  new ARIOToken(65 * 10 ** 12).toAmount(65_000_000);
+  new ARIOToken(65 * 10 ** 12).toMARIO().value;
 const teamWalletBalance =
   process.env.ARIO_TEAM_WALLET_BALANCE ||
-  new ARIOToken(50 * 10 ** 12).toAmount(50_000_000);
-const teamWalletAddress = (process.env.ARIO_TEAM_WALLET_ADDRESS || '')
+  new ARIOToken(50 * 10 ** 12).toMARIO().value;
+const teamWalletAddress = (
+  process.env.ARIO_TEAM_WALLET_ADDRESS ||
+  'OZJjbPv98Qp8pJTZbKCmwlmhutGCW_zZ-18MjdBZQRY,DyQ3ZT4LSxSqx9CqFBb7O_28vE3bc7HsVA6jDvufpwc'
+)
   .trim()
   .split(',');
 const ownerBalance = 10 ** 15 - protocolBalance - teamWalletBalance;
@@ -33,7 +36,7 @@ const { id } = await networkProcess.send({
   data: ```
     PrimaryNames.owners={}
     PrimaryNames.names={}
-    GatewayRegistry = {}
+    GatewayRegistry={}
     NameRegistry.records={}
     NameRegistry.returned={}
     Epochs={}
@@ -45,4 +48,4 @@ const { id } = await networkProcess.send({
   ```,
   signer,
 });
-console.log(`Evolve result tx: ${id}`);
+console.log(`Testnet reset tx: ${id}`);

--- a/tools/testnet-reset.mjs
+++ b/tools/testnet-reset.mjs
@@ -18,34 +18,55 @@ const networkProcess = new AOProcess({
   }),
 });
 
-const protocolBalance =
-  process.env.ARIO_PROTOCOL_BALANCE ||
-  new ARIOToken(65 * 10 ** 12).toMARIO().value;
-const teamWalletBalance =
-  process.env.ARIO_TEAM_WALLET_BALANCE ||
-  new ARIOToken(50 * 10 ** 12).toMARIO().value;
+// 1B tARIO total supply
+const totalSupply = new ARIOToken(10 ** 9).toMARIO().valueOf();
+// 65M tARIO to the protocol
+const protocolBalance = new ARIOToken(65 * 10 ** 6).toMARIO().valueOf();
+// 50M tARIO to each of the team wallets
+const teamWalletBalance = new ARIOToken(50 * 10 ** 6).toMARIO().valueOf();
+// any team wallets needed for testing
 const teamWalletAddress = (
   process.env.ARIO_TEAM_WALLET_ADDRESS ||
   'OZJjbPv98Qp8pJTZbKCmwlmhutGCW_zZ-18MjdBZQRY,DyQ3ZT4LSxSqx9CqFBb7O_28vE3bc7HsVA6jDvufpwc'
 )
   .trim()
   .split(',');
-const ownerBalance = 10 ** 15 - protocolBalance - teamWalletBalance;
+// the owner balance is the total supply minus the protocol balance and the team wallet balance
+const ownerBalance = totalSupply - protocolBalance - teamWalletBalance;
 const { id } = await networkProcess.send({
   tags: [{ name: 'Action', value: 'Eval' }],
-  data: ```
+  data: `
     PrimaryNames.owners={}
     PrimaryNames.names={}
     GatewayRegistry={}
-    NameRegistry.records={}
+    NameRegistry.records={
+      ardrive={
+        processId = "FAoLsl-FuRYap2WCTLE1xkMzoK3fuu2Pq-E5-F9Cy-A",
+        purchasePrice = 0,
+        type = "permabuy",
+        startTimestamp = 1741799881987,
+        undernameLimit = 10
+      },
+      ["undername-limits"]={
+        processId = "YvtwbdthqwEjAvuPMckzBSWyeGFlcLoJzpbLdyFNY-w",
+        purchasePrice = 0,
+        type = "permabuy",
+        startTimestamp = 1741799881987,
+        undernameLimit = 10
+      }
+    }
     NameRegistry.returned={}
     Epochs={}
     Balances={
-        [Owner]=${ownerBalance},
-        ${processId}=${protocolBalance},
-        ${teamWalletAddress.map((address) => `${address}=${teamWalletBalance}`).join(',\n')}
+      [Owner]=${ownerBalance},
+      ${processId}=${protocolBalance},
+      ${teamWalletAddress.map((address) => `["${address}"]=${teamWalletBalance}`).join(',\n')}
     }
-  ```,
+  `,
   signer,
 });
 console.log(`Testnet reset tx: ${id}`);
+
+/**
+ *
+ */

--- a/tools/testnet-reset.mjs
+++ b/tools/testnet-reset.mjs
@@ -1,0 +1,48 @@
+import {
+  AOProcess,
+  createAoSigner,
+  ArweaveSigner,
+  ARIO_TESTNET_PROCESS_ID,
+  ARIOToken,
+} from '@ar.io/sdk/node';
+import { connect } from '@permaweb/aoconnect';
+
+const wallet = JSON.parse(process.env.WALLET);
+const processId =
+  process.env.ARIO_NETWORK_PROCESS_ID || ARIO_TESTNET_PROCESS_ID;
+const signer = createAoSigner(new ArweaveSigner(wallet));
+const networkProcess = new AOProcess({
+  processId,
+  ao: connect({
+    CU_URL: process.env.AO_CU_URL,
+  }),
+});
+
+const protocolBalance =
+  process.env.ARIO_PROTOCOL_BALANCE ||
+  new ARIOToken(65 * 10 ** 12).toAmount(65_000_000);
+const teamWalletBalance =
+  process.env.ARIO_TEAM_WALLET_BALANCE ||
+  new ARIOToken(50 * 10 ** 12).toAmount(50_000_000);
+const teamWalletAddress = (process.env.ARIO_TEAM_WALLET_ADDRESS || '')
+  .trim()
+  .split(',');
+const ownerBalance = 10 ** 15 - protocolBalance - teamWalletBalance;
+const { id } = await networkProcess.send({
+  tags: [{ name: 'Action', value: 'Eval' }],
+  data: ```
+    PrimaryNames.owners={}
+    PrimaryNames.names={}
+    GatewayRegistry = {}
+    NameRegistry.records={}
+    NameRegistry.returned={}
+    Epochs={}
+    Balances={
+        [Owner]=${ownerBalance},
+        ${processId}=${protocolBalance},
+        ${teamWalletAddress.map((address) => `${address}=${teamWalletBalance}`).join(',\n')}
+    }
+  ```,
+  signer,
+});
+console.log(`Evolve result tx: ${id}`);


### PR DESCRIPTION
This is a simple cron to reset the testnet process state on the first of every month.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced an automated workflow to reset the AR.IO testnet monthly or on demand.
	- Added a script to reset the testnet state, including balances and registries, as part of the workflow.
	- Implemented Slack notifications to inform about the status of each testnet reset operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->