### PR TITLE
Add pagination filters

### DIFF
--- a/spec/arns_spec.lua
+++ b/spec/arns_spec.lua
@@ -1815,28 +1815,51 @@ describe("arns", function()
 					},
 				},
 			}, paginatedRecords3)
-			local paginatedRecords4 = arns.getPaginatedRecords(paginatedRecords3.nextCursor, 1, "endTimestamp", "asc")
-			assert.are.same({
-				limit = 1,
-				sortBy = "endTimestamp",
-				sortOrder = "asc",
-				hasMore = false,
-				totalItems = 4,
-				nextCursor = nil,
-				items = {
-					{
-						name = "permabuy-record",
-						endTimestamp = nil,
-						processId = "permabuy-process-id",
-						purchasePrice = basePriceForNineLetterName,
-						startTimestamp = 0,
-						type = "permabuy",
-						undernameLimit = 10,
-					},
-				},
-			}, paginatedRecords4)
-		end)
-	end)
+                        local paginatedRecords4 = arns.getPaginatedRecords(paginatedRecords3.nextCursor, 1, "endTimestamp", "asc")
+                        assert.are.same({
+                                limit = 1,
+                                sortBy = "endTimestamp",
+                                sortOrder = "asc",
+                                hasMore = false,
+                                totalItems = 4,
+                                nextCursor = nil,
+                                items = {
+                                        {
+                                                name = "permabuy-record",
+                                                endTimestamp = nil,
+                                                processId = "permabuy-process-id",
+                                                purchasePrice = basePriceForNineLetterName,
+                                                startTimestamp = 0,
+                                                type = "permabuy",
+                                                undernameLimit = 10,
+                                        },
+                                },
+                        }, paginatedRecords4)
+                end)
+
+                it("filters records when filters are provided", function()
+                        local result = arns.getPaginatedRecords(nil, 10, "name", "asc", { type = { "permabuy" } })
+                        assert.are.same({
+                                limit = 10,
+                                sortBy = "name",
+                                sortOrder = "asc",
+                                hasMore = false,
+                                totalItems = 1,
+                                nextCursor = nil,
+                                items = {
+                                        {
+                                                name = "permabuy-record",
+                                                endTimestamp = nil,
+                                                processId = "permabuy-process-id",
+                                                purchasePrice = basePriceForNineLetterName,
+                                                startTimestamp = 0,
+                                                type = "permabuy",
+                                                undernameLimit = 10,
+                                        },
+                                },
+                        }, result)
+                end)
+        end)
 
 	describe("getPaginatedReservedNames", function()
 		before_each(function()

--- a/src/arns.lua
+++ b/src/arns.lua
@@ -175,8 +175,9 @@ end
 --- @param limit number The limit of records to return
 --- @param sortBy string The field to sort by
 --- @param sortOrder string The order to sort by
+--- @param filters table|nil Optional filter criteria
 --- @return PaginatedTable<Record> The paginated records
-function arns.getPaginatedRecords(cursor, limit, sortBy, sortOrder)
+function arns.getPaginatedRecords(cursor, limit, sortBy, sortOrder, filters)
 	--- @type Record[]
 	local recordsArray = {}
 	local cursorField = "name" -- the cursor will be the name
@@ -187,7 +188,7 @@ function arns.getPaginatedRecords(cursor, limit, sortBy, sortOrder)
 		table.insert(recordsArray, recordCopy)
 	end
 
-	return utils.paginateTableWithCursor(recordsArray, cursor, cursorField, limit, sortBy, sortOrder)
+        return utils.paginateTableWithCursor(recordsArray, cursor, cursorField, limit, sortBy, sortOrder, filters)
 end
 
 --- Get paginated reserved names

--- a/src/main.lua
+++ b/src/main.lua
@@ -2137,11 +2137,17 @@ end)
 -- Pagination handlers
 
 addEventingHandler("paginatedRecords", function(msg)
-	return msg.Action == "Paginated-Records" or msg.Action == ActionMap.Records
+        return msg.Action == "Paginated-Records" or msg.Action == ActionMap.Records
 end, function(msg)
-	local page = utils.parsePaginationTags(msg)
-	local result = arns.getPaginatedRecords(page.cursor, page.limit, page.sortBy or "startTimestamp", page.sortOrder)
-	Send(msg, { Target = msg.From, Action = "Records-Notice", Data = json.encode(result) })
+        local page = utils.parsePaginationTags(msg)
+        local result = arns.getPaginatedRecords(
+                page.cursor,
+                page.limit,
+                page.sortBy or "startTimestamp",
+                page.sortOrder,
+                page.filters
+        )
+        Send(msg, { Target = msg.From, Action = "Records-Notice", Data = json.encode(result) })
 end)
 
 addEventingHandler("paginatedGateways", function(msg)


### PR DESCRIPTION
## Summary
- add filter parsing to `parsePaginationTags`
- support filter predicates in `paginateTableWithCursor`
- expose filter param in `getPaginatedRecords`
- pass filters through RECORDS handler
- test pagination filters
- optimize createFilterFunction by converting value arrays to lookup maps
- add tests for array filter support
- restrict pagination filter to tables only

## Testing
- `yarn test:unit` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684caa7a01808328b8e807f7940a86f4