### PR TITLE
Add SES email provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,27 @@ dependencies = {
 }
 ```
 
+### Email Provider
+
+The `tools/email/ses.mjs` module exports `AWSEmailProvider`, a simple
+wrapper around Amazon SES.
+
+```javascript
+import AWSEmailProvider from './tools/email/ses.mjs';
+
+const ses = new AWSEmailProvider({
+  region: 'us-east-1',
+  credentials: { accessKeyId: 'AKIA...', secretAccessKey: 'SECRET' },
+});
+
+await ses.sendEmail({
+  from: 'noreply@example.com',
+  to: 'user@example.com',
+  subject: 'Hello',
+  text: 'Welcome to ar.io',
+});
+```
+
 [contract whitepaper]: https://whitepaper.ar.io
 [aoconnect]: https://github.com/permaweb/ao/tree/main/connect
 [ar-io/aos]: https://github.com/ar-io/aos

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@permaweb/ao-loader": "^0.0.36",
     "@permaweb/aoconnect": "^0.0.59",
     "arweave": "^1.15.1",
+    "@aws-sdk/client-ses": "^3.602.0",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",
     "markdown-toc-gen": "^1.1.0",

--- a/tools/email/ses.mjs
+++ b/tools/email/ses.mjs
@@ -1,0 +1,50 @@
+import { SESClient, SendEmailCommand } from '@aws-sdk/client-ses';
+
+/**
+ * @typedef {Object} SendEmailParams
+ * @property {string | string[]} to
+ * @property {string} from
+ * @property {string} subject
+ * @property {string} text
+ * @property {string} [html]
+ */
+
+/**
+ * @typedef {Object} EmailProvider
+ * @property {(params: SendEmailParams) => Promise<any>} sendEmail
+ */
+
+/**
+ * Email provider backed by AWS SES.
+ *
+ * @implements {EmailProvider}
+ */
+export class AWSEmailProvider {
+  /**
+   * @param {import('@aws-sdk/client-ses').SESClientConfig} config
+   */
+  constructor(config = {}) {
+    this.client = new SESClient(config);
+  }
+
+  /**
+   * @param {SendEmailParams} params
+   */
+  async sendEmail({ to, from, subject, text, html }) {
+    const command = new SendEmailCommand({
+      Source: from,
+      Destination: { ToAddresses: Array.isArray(to) ? to : [to] },
+      Message: {
+        Subject: { Data: subject },
+        Body: {
+          Text: { Data: text },
+          ...(html ? { Html: { Data: html } } : {}),
+        },
+      },
+    });
+
+    return this.client.send(command);
+  }
+}
+
+export { AWSEmailProvider as default };


### PR DESCRIPTION
## Summary
- add an SES provider utility
- document usage of SES email helper
- include `@aws-sdk/client-ses` as a dev dependency
- implement AWSEmailProvider class implementing EmailProvider

## Testing
- `yarn test:unit` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684f001ea5e0832891e6a97f829715b7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an email provider that enables sending emails using Amazon SES.

- **Documentation**
  - Added a new "Email Provider" section to the documentation with usage examples for the new email provider.

- **Chores**
  - Added the AWS SES client as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->